### PR TITLE
[SECURESIGN-2377] Display TUF certificates information

### DIFF
--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -122,6 +122,37 @@ func (h *Handler) GetApiV1TrustRootMetadata(w http.ResponseWriter, r *http.Reque
 	writeJSON(w, http.StatusOK, resp)
 }
 
+func (h *Handler) GetApiV1TrustTargets(w http.ResponseWriter, r *http.Request) {
+	tufRepoUrl := r.URL.Query().Get("tufRepositoryUrl")
+	resp, err := h.trustService.GetTargetsList(r.Context(), tufRepoUrl)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	writeJSON(w, http.StatusOK, resp)
+}
+
+func (h *Handler) GetApiV1TrustTarget(w http.ResponseWriter, r *http.Request) {
+	tufRepoUrl := r.URL.Query().Get("tufRepositoryUrl")
+	target := r.URL.Query().Get("target")
+	resp, err := h.trustService.GetTarget(r.Context(), tufRepoUrl, target)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	writeJSON(w, http.StatusOK, resp)
+}
+
+func (h *Handler) GetApiV1TrustTargetsCertificates(w http.ResponseWriter, r *http.Request) {
+	tufRepoUrl := r.URL.Query().Get("tufRepositoryUrl")
+	resp, err := h.trustService.GetCertificatesInfo(r.Context(), tufRepoUrl)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	writeJSON(w, http.StatusOK, resp)
+}
+
 func (h *Handler) ServeSwaggerUI(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
 

--- a/internal/api/openapi/rhtas-console.yaml
+++ b/internal/api/openapi/rhtas-console.yaml
@@ -284,6 +284,115 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
+  /api/v1/trust/targets:
+    get:
+      summary: Get TUF Targets List
+      description: |
+        Fetches and returns the list of TUF target files from the specified repository.
+      tags:
+        - Trust
+      parameters:
+        - name: tufRepositoryUrl
+          in: query
+          required: true
+          schema:
+            type: string
+            description: URL of the TUF repository
+            example: https://tuf-repo-cdn.sigstore.dev/
+      responses:
+        '200':
+          description: List of TUF target names
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TargetsList'
+        '400':
+          description: Invalid input
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '500':
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+  /api/v1/trust/target:
+    get:
+      summary: Get TUF Target File Content
+      description: |
+        Fetches and returns the raw content of a specific TUF target file from the specified repository.
+      tags:
+        - Trust
+      parameters:
+        - name: tufRepositoryUrl
+          in: query
+          required: true
+          schema:
+            type: string
+            description: URL of the TUF repository
+            example: https://tuf-repo-cdn.sigstore.dev/
+        - name: target
+          in: query
+          required: true
+          schema:
+            type: string
+            description: Target filename
+            example: rekor.pub
+      responses:
+        '200':
+          description: Content of the requested TUF target file
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TargetContent'
+        '400':
+          description: Invalid input
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '500':
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+  /api/v1/trust/targets/certificates:
+    get:
+      summary: Get Certificates Information
+      description: |
+        Fetches and returns the list information of all targets of type certificate.
+      tags:
+        - Trust
+      parameters:
+        - name: tufRepositoryUrl
+          in: query
+          required: true
+          schema:
+            type: string
+            description: URL of the TUF repository
+            example: https://tuf-repo-cdn.sigstore.dev/
+      responses:
+        '200':
+          description: List of TUF target names
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CertificateInfoList'
+        '400':
+          description: Invalid input
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '500':
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
 components:
   securitySchemes:
     basicAuth:
@@ -626,6 +735,59 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/RootMetadataInfo'
+      required:
+        - data
+    TargetsList:
+      type: object
+      properties:
+        targets:
+          type: array
+          items:
+            type: string
+      required:
+        - targets
+    TargetContent:
+      type: object
+      properties:
+        content:
+          type: string
+      required:
+        - content
+    CertificateInfo:
+      type: object
+      properties:
+        subject:
+          type: string
+          description: Certificate subject
+        issuer:
+          type: string
+          description: Certificate issuer
+        type:
+          type: string
+          description: Target type
+        status:
+          type: string
+          description: Status of the target to which the certificate is associated.
+        target:
+          type: string
+          description:  The TUF target to which the certificate is associated.
+        expiration:
+          type: string
+          description: Expiration date and time of the certificate (notAfter).
+      required:
+        - subject
+        - issuer
+        - type
+        - status
+        - target
+        - expiration
+    CertificateInfoList:
+      type: object
+      properties:
+        data:
+          type: array
+          items:
+            $ref: '#/components/schemas/CertificateInfo'
       required:
         - data
     Error:

--- a/internal/api/openapi/rhtas-console.yaml
+++ b/internal/api/openapi/rhtas-console.yaml
@@ -225,7 +225,7 @@ paths:
       parameters:
         - name: tufRepositoryUrl
           in: query
-          required: true
+          required: false
           schema:
             type: string
             description: URL of the TUF repository
@@ -260,7 +260,7 @@ paths:
       parameters:
         - name: tufRepositoryUrl
           in: query
-          required: true
+          required: false
           schema:
             type: string
             description: URL of the TUF repository
@@ -294,7 +294,7 @@ paths:
       parameters:
         - name: tufRepositoryUrl
           in: query
-          required: true
+          required: false
           schema:
             type: string
             description: URL of the TUF repository
@@ -328,7 +328,7 @@ paths:
       parameters:
         - name: tufRepositoryUrl
           in: query
-          required: true
+          required: false
           schema:
             type: string
             description: URL of the TUF repository
@@ -369,7 +369,7 @@ paths:
       parameters:
         - name: tufRepositoryUrl
           in: query
-          required: true
+          required: false
           schema:
             type: string
             description: URL of the TUF repository

--- a/internal/api/routes.go
+++ b/internal/api/routes.go
@@ -17,6 +17,9 @@ func RegisterRoutes(r *chi.Mux, as services.ArtifactService, rs services.RekorSe
 	r.Get("/api/v1/rekor/public-key", handler.GetApiV1RekorPublicKey)
 	r.Get("/api/v1/trust/config", handler.GetApiV1TrustConfig)
 	r.Get("/api/v1/trust/root-metadata-info", handler.GetApiV1TrustRootMetadata)
+	r.Get("/api/v1/trust/targets", handler.GetApiV1TrustTargets)
+	r.Get("/api/v1/trust/target", handler.GetApiV1TrustTarget)
+	r.Get("/api/v1/trust/targets/certificates", handler.GetApiV1TrustTargetsCertificates)
 	r.Get("/swagger-ui", handler.ServeSwaggerUI)
 	r.Get("/rhtas-console.yaml", handler.ServeOpenAPIFile)
 }

--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -60,6 +60,32 @@ type ArtifactPolicies struct {
 	} `json:"policies"`
 }
 
+// CertificateInfo defines model for CertificateInfo.
+type CertificateInfo struct {
+	// Expiration Expiration date and time of the certificate (notAfter).
+	Expiration string `json:"expiration"`
+
+	// Issuer Certificate issuer
+	Issuer string `json:"issuer"`
+
+	// Status Status of the target to which the certificate is associated.
+	Status string `json:"status"`
+
+	// Subject Certificate subject
+	Subject string `json:"subject"`
+
+	// Target The TUF target to which the certificate is associated.
+	Target string `json:"target"`
+
+	// Type Target type
+	Type string `json:"type"`
+}
+
+// CertificateInfoList defines model for CertificateInfoList.
+type CertificateInfoList struct {
+	Data []CertificateInfo `json:"data"`
+}
+
 // Error defines model for Error.
 type Error struct {
 	// Error Error message
@@ -195,6 +221,16 @@ type SignArtifactResponse struct {
 	Success bool `json:"success"`
 }
 
+// TargetContent defines model for TargetContent.
+type TargetContent struct {
+	Content string `json:"content"`
+}
+
+// TargetsList defines model for TargetsList.
+type TargetsList struct {
+	Targets []string `json:"targets"`
+}
+
 // TrustConfig defines model for TrustConfig.
 type TrustConfig struct {
 	FulcioCertAuthorities []struct {
@@ -275,6 +311,22 @@ type GetApiV1TrustRootMetadataInfoParams struct {
 	TufRepositoryUrl string `form:"tufRepositoryUrl" json:"tufRepositoryUrl"`
 }
 
+// GetApiV1TrustTargetParams defines parameters for GetApiV1TrustTarget.
+type GetApiV1TrustTargetParams struct {
+	TufRepositoryUrl string `form:"tufRepositoryUrl" json:"tufRepositoryUrl"`
+	Target           string `form:"target" json:"target"`
+}
+
+// GetApiV1TrustTargetsParams defines parameters for GetApiV1TrustTargets.
+type GetApiV1TrustTargetsParams struct {
+	TufRepositoryUrl string `form:"tufRepositoryUrl" json:"tufRepositoryUrl"`
+}
+
+// GetApiV1TrustTargetsCertificatesParams defines parameters for GetApiV1TrustTargetsCertificates.
+type GetApiV1TrustTargetsCertificatesParams struct {
+	TufRepositoryUrl string `form:"tufRepositoryUrl" json:"tufRepositoryUrl"`
+}
+
 // PostApiV1ArtifactsSignJSONRequestBody defines body for PostApiV1ArtifactsSign for application/json ContentType.
 type PostApiV1ArtifactsSignJSONRequestBody = SignArtifactRequest
 
@@ -307,6 +359,15 @@ type ServerInterface interface {
 	// Get TUF Root Metadata
 	// (GET /api/v1/trust/root-metadata-info)
 	GetApiV1TrustRootMetadataInfo(w http.ResponseWriter, r *http.Request, params GetApiV1TrustRootMetadataInfoParams)
+	// Get TUF Target File Content
+	// (GET /api/v1/trust/target)
+	GetApiV1TrustTarget(w http.ResponseWriter, r *http.Request, params GetApiV1TrustTargetParams)
+	// Get TUF Targets List
+	// (GET /api/v1/trust/targets)
+	GetApiV1TrustTargets(w http.ResponseWriter, r *http.Request, params GetApiV1TrustTargetsParams)
+	// Get Certificates Information
+	// (GET /api/v1/trust/targets/certificates)
+	GetApiV1TrustTargetsCertificates(w http.ResponseWriter, r *http.Request, params GetApiV1TrustTargetsCertificatesParams)
 
 	// (GET /healthz)
 	GetHealthz(w http.ResponseWriter, r *http.Request)
@@ -361,6 +422,24 @@ func (_ Unimplemented) GetApiV1TrustConfig(w http.ResponseWriter, r *http.Reques
 // Get TUF Root Metadata
 // (GET /api/v1/trust/root-metadata-info)
 func (_ Unimplemented) GetApiV1TrustRootMetadataInfo(w http.ResponseWriter, r *http.Request, params GetApiV1TrustRootMetadataInfoParams) {
+	w.WriteHeader(http.StatusNotImplemented)
+}
+
+// Get TUF Target File Content
+// (GET /api/v1/trust/target)
+func (_ Unimplemented) GetApiV1TrustTarget(w http.ResponseWriter, r *http.Request, params GetApiV1TrustTargetParams) {
+	w.WriteHeader(http.StatusNotImplemented)
+}
+
+// Get TUF Targets List
+// (GET /api/v1/trust/targets)
+func (_ Unimplemented) GetApiV1TrustTargets(w http.ResponseWriter, r *http.Request, params GetApiV1TrustTargetsParams) {
+	w.WriteHeader(http.StatusNotImplemented)
+}
+
+// Get Certificates Information
+// (GET /api/v1/trust/targets/certificates)
+func (_ Unimplemented) GetApiV1TrustTargetsCertificates(w http.ResponseWriter, r *http.Request, params GetApiV1TrustTargetsCertificatesParams) {
 	w.WriteHeader(http.StatusNotImplemented)
 }
 
@@ -578,6 +657,123 @@ func (siw *ServerInterfaceWrapper) GetApiV1TrustRootMetadataInfo(w http.Response
 	handler.ServeHTTP(w, r)
 }
 
+// GetApiV1TrustTarget operation middleware
+func (siw *ServerInterfaceWrapper) GetApiV1TrustTarget(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+
+	// Parameter object where we will unmarshal all parameters from the context
+	var params GetApiV1TrustTargetParams
+
+	// ------------- Required query parameter "tufRepositoryUrl" -------------
+
+	if paramValue := r.URL.Query().Get("tufRepositoryUrl"); paramValue != "" {
+
+	} else {
+		siw.ErrorHandlerFunc(w, r, &RequiredParamError{ParamName: "tufRepositoryUrl"})
+		return
+	}
+
+	err = runtime.BindQueryParameter("form", true, true, "tufRepositoryUrl", r.URL.Query(), &params.TufRepositoryUrl)
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "tufRepositoryUrl", Err: err})
+		return
+	}
+
+	// ------------- Required query parameter "target" -------------
+
+	if paramValue := r.URL.Query().Get("target"); paramValue != "" {
+
+	} else {
+		siw.ErrorHandlerFunc(w, r, &RequiredParamError{ParamName: "target"})
+		return
+	}
+
+	err = runtime.BindQueryParameter("form", true, true, "target", r.URL.Query(), &params.Target)
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "target", Err: err})
+		return
+	}
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.GetApiV1TrustTarget(w, r, params)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// GetApiV1TrustTargets operation middleware
+func (siw *ServerInterfaceWrapper) GetApiV1TrustTargets(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+
+	// Parameter object where we will unmarshal all parameters from the context
+	var params GetApiV1TrustTargetsParams
+
+	// ------------- Required query parameter "tufRepositoryUrl" -------------
+
+	if paramValue := r.URL.Query().Get("tufRepositoryUrl"); paramValue != "" {
+
+	} else {
+		siw.ErrorHandlerFunc(w, r, &RequiredParamError{ParamName: "tufRepositoryUrl"})
+		return
+	}
+
+	err = runtime.BindQueryParameter("form", true, true, "tufRepositoryUrl", r.URL.Query(), &params.TufRepositoryUrl)
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "tufRepositoryUrl", Err: err})
+		return
+	}
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.GetApiV1TrustTargets(w, r, params)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// GetApiV1TrustTargetsCertificates operation middleware
+func (siw *ServerInterfaceWrapper) GetApiV1TrustTargetsCertificates(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+
+	// Parameter object where we will unmarshal all parameters from the context
+	var params GetApiV1TrustTargetsCertificatesParams
+
+	// ------------- Required query parameter "tufRepositoryUrl" -------------
+
+	if paramValue := r.URL.Query().Get("tufRepositoryUrl"); paramValue != "" {
+
+	} else {
+		siw.ErrorHandlerFunc(w, r, &RequiredParamError{ParamName: "tufRepositoryUrl"})
+		return
+	}
+
+	err = runtime.BindQueryParameter("form", true, true, "tufRepositoryUrl", r.URL.Query(), &params.TufRepositoryUrl)
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "tufRepositoryUrl", Err: err})
+		return
+	}
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.GetApiV1TrustTargetsCertificates(w, r, params)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
 // GetHealthz operation middleware
 func (siw *ServerInterfaceWrapper) GetHealthz(w http.ResponseWriter, r *http.Request) {
 
@@ -728,6 +924,15 @@ func HandlerWithOptions(si ServerInterface, options ChiServerOptions) http.Handl
 	})
 	r.Group(func(r chi.Router) {
 		r.Get(options.BaseURL+"/api/v1/trust/root-metadata-info", wrapper.GetApiV1TrustRootMetadataInfo)
+	})
+	r.Group(func(r chi.Router) {
+		r.Get(options.BaseURL+"/api/v1/trust/target", wrapper.GetApiV1TrustTarget)
+	})
+	r.Group(func(r chi.Router) {
+		r.Get(options.BaseURL+"/api/v1/trust/targets", wrapper.GetApiV1TrustTargets)
+	})
+	r.Group(func(r chi.Router) {
+		r.Get(options.BaseURL+"/api/v1/trust/targets/certificates", wrapper.GetApiV1TrustTargetsCertificates)
 	})
 	r.Group(func(r chi.Router) {
 		r.Get(options.BaseURL+"/healthz", wrapper.GetHealthz)

--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -303,28 +303,28 @@ type GetApiV1ArtifactsImageParams struct {
 
 // GetApiV1TrustConfigParams defines parameters for GetApiV1TrustConfig.
 type GetApiV1TrustConfigParams struct {
-	TufRepositoryUrl string `form:"tufRepositoryUrl" json:"tufRepositoryUrl"`
+	TufRepositoryUrl *string `form:"tufRepositoryUrl,omitempty" json:"tufRepositoryUrl,omitempty"`
 }
 
 // GetApiV1TrustRootMetadataInfoParams defines parameters for GetApiV1TrustRootMetadataInfo.
 type GetApiV1TrustRootMetadataInfoParams struct {
-	TufRepositoryUrl string `form:"tufRepositoryUrl" json:"tufRepositoryUrl"`
+	TufRepositoryUrl *string `form:"tufRepositoryUrl,omitempty" json:"tufRepositoryUrl,omitempty"`
 }
 
 // GetApiV1TrustTargetParams defines parameters for GetApiV1TrustTarget.
 type GetApiV1TrustTargetParams struct {
-	TufRepositoryUrl string `form:"tufRepositoryUrl" json:"tufRepositoryUrl"`
-	Target           string `form:"target" json:"target"`
+	TufRepositoryUrl *string `form:"tufRepositoryUrl,omitempty" json:"tufRepositoryUrl,omitempty"`
+	Target           string  `form:"target" json:"target"`
 }
 
 // GetApiV1TrustTargetsParams defines parameters for GetApiV1TrustTargets.
 type GetApiV1TrustTargetsParams struct {
-	TufRepositoryUrl string `form:"tufRepositoryUrl" json:"tufRepositoryUrl"`
+	TufRepositoryUrl *string `form:"tufRepositoryUrl,omitempty" json:"tufRepositoryUrl,omitempty"`
 }
 
 // GetApiV1TrustTargetsCertificatesParams defines parameters for GetApiV1TrustTargetsCertificates.
 type GetApiV1TrustTargetsCertificatesParams struct {
-	TufRepositoryUrl string `form:"tufRepositoryUrl" json:"tufRepositoryUrl"`
+	TufRepositoryUrl *string `form:"tufRepositoryUrl,omitempty" json:"tufRepositoryUrl,omitempty"`
 }
 
 // PostApiV1ArtifactsSignJSONRequestBody defines body for PostApiV1ArtifactsSign for application/json ContentType.
@@ -597,16 +597,9 @@ func (siw *ServerInterfaceWrapper) GetApiV1TrustConfig(w http.ResponseWriter, r 
 	// Parameter object where we will unmarshal all parameters from the context
 	var params GetApiV1TrustConfigParams
 
-	// ------------- Required query parameter "tufRepositoryUrl" -------------
+	// ------------- Optional query parameter "tufRepositoryUrl" -------------
 
-	if paramValue := r.URL.Query().Get("tufRepositoryUrl"); paramValue != "" {
-
-	} else {
-		siw.ErrorHandlerFunc(w, r, &RequiredParamError{ParamName: "tufRepositoryUrl"})
-		return
-	}
-
-	err = runtime.BindQueryParameter("form", true, true, "tufRepositoryUrl", r.URL.Query(), &params.TufRepositoryUrl)
+	err = runtime.BindQueryParameter("form", true, false, "tufRepositoryUrl", r.URL.Query(), &params.TufRepositoryUrl)
 	if err != nil {
 		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "tufRepositoryUrl", Err: err})
 		return
@@ -631,16 +624,9 @@ func (siw *ServerInterfaceWrapper) GetApiV1TrustRootMetadataInfo(w http.Response
 	// Parameter object where we will unmarshal all parameters from the context
 	var params GetApiV1TrustRootMetadataInfoParams
 
-	// ------------- Required query parameter "tufRepositoryUrl" -------------
+	// ------------- Optional query parameter "tufRepositoryUrl" -------------
 
-	if paramValue := r.URL.Query().Get("tufRepositoryUrl"); paramValue != "" {
-
-	} else {
-		siw.ErrorHandlerFunc(w, r, &RequiredParamError{ParamName: "tufRepositoryUrl"})
-		return
-	}
-
-	err = runtime.BindQueryParameter("form", true, true, "tufRepositoryUrl", r.URL.Query(), &params.TufRepositoryUrl)
+	err = runtime.BindQueryParameter("form", true, false, "tufRepositoryUrl", r.URL.Query(), &params.TufRepositoryUrl)
 	if err != nil {
 		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "tufRepositoryUrl", Err: err})
 		return
@@ -665,16 +651,9 @@ func (siw *ServerInterfaceWrapper) GetApiV1TrustTarget(w http.ResponseWriter, r 
 	// Parameter object where we will unmarshal all parameters from the context
 	var params GetApiV1TrustTargetParams
 
-	// ------------- Required query parameter "tufRepositoryUrl" -------------
+	// ------------- Optional query parameter "tufRepositoryUrl" -------------
 
-	if paramValue := r.URL.Query().Get("tufRepositoryUrl"); paramValue != "" {
-
-	} else {
-		siw.ErrorHandlerFunc(w, r, &RequiredParamError{ParamName: "tufRepositoryUrl"})
-		return
-	}
-
-	err = runtime.BindQueryParameter("form", true, true, "tufRepositoryUrl", r.URL.Query(), &params.TufRepositoryUrl)
+	err = runtime.BindQueryParameter("form", true, false, "tufRepositoryUrl", r.URL.Query(), &params.TufRepositoryUrl)
 	if err != nil {
 		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "tufRepositoryUrl", Err: err})
 		return
@@ -714,16 +693,9 @@ func (siw *ServerInterfaceWrapper) GetApiV1TrustTargets(w http.ResponseWriter, r
 	// Parameter object where we will unmarshal all parameters from the context
 	var params GetApiV1TrustTargetsParams
 
-	// ------------- Required query parameter "tufRepositoryUrl" -------------
+	// ------------- Optional query parameter "tufRepositoryUrl" -------------
 
-	if paramValue := r.URL.Query().Get("tufRepositoryUrl"); paramValue != "" {
-
-	} else {
-		siw.ErrorHandlerFunc(w, r, &RequiredParamError{ParamName: "tufRepositoryUrl"})
-		return
-	}
-
-	err = runtime.BindQueryParameter("form", true, true, "tufRepositoryUrl", r.URL.Query(), &params.TufRepositoryUrl)
+	err = runtime.BindQueryParameter("form", true, false, "tufRepositoryUrl", r.URL.Query(), &params.TufRepositoryUrl)
 	if err != nil {
 		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "tufRepositoryUrl", Err: err})
 		return
@@ -748,16 +720,9 @@ func (siw *ServerInterfaceWrapper) GetApiV1TrustTargetsCertificates(w http.Respo
 	// Parameter object where we will unmarshal all parameters from the context
 	var params GetApiV1TrustTargetsCertificatesParams
 
-	// ------------- Required query parameter "tufRepositoryUrl" -------------
+	// ------------- Optional query parameter "tufRepositoryUrl" -------------
 
-	if paramValue := r.URL.Query().Get("tufRepositoryUrl"); paramValue != "" {
-
-	} else {
-		siw.ErrorHandlerFunc(w, r, &RequiredParamError{ParamName: "tufRepositoryUrl"})
-		return
-	}
-
-	err = runtime.BindQueryParameter("form", true, true, "tufRepositoryUrl", r.URL.Query(), &params.TufRepositoryUrl)
+	err = runtime.BindQueryParameter("form", true, false, "tufRepositoryUrl", r.URL.Query(), &params.TufRepositoryUrl)
 	if err != nil {
 		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "tufRepositoryUrl", Err: err})
 		return

--- a/internal/services/trust.go
+++ b/internal/services/trust.go
@@ -149,11 +149,9 @@ func (s *trustService) GetCertificatesInfo(ctx context.Context, tufRepoUrl strin
 	if err != nil {
 		return models.CertificateInfoList{}, fmt.Errorf("fetching TUF root metadata: %w", err)
 	}
-	certificates := []string{}
 	for target, info := range targetMetadataSpecs {
 		// Only targets of type certificate
 		if strings.ToLower(info["type"]) == "fulcio" || strings.ToLower(info["type"]) == "tsa" {
-			certificates = append(certificates, target)
 			cert_content, err := s.GetTarget(ctx, tufRepoUrl, target)
 			if err != nil {
 				return models.CertificateInfoList{}, fmt.Errorf("getting target certificate content: %w", err)

--- a/internal/services/trust.go
+++ b/internal/services/trust.go
@@ -2,7 +2,9 @@ package services
 
 import (
 	"context"
+	"crypto/x509"
 	"encoding/json"
+	"encoding/pem"
 	"fmt"
 	"io"
 	"net/http"
@@ -24,6 +26,9 @@ import (
 type TrustService interface {
 	GetTrustConfig(ctx context.Context, tufRepoUrl string) (models.TrustConfig, error)
 	GetTrustRootMetadataInfo(tufRepoUrl string) (models.RootMetadataInfoList, error)
+	GetTargetsList(ctx context.Context, tufRepoUrl string) (models.TargetsList, error)
+	GetTarget(ctx context.Context, tufRepoUrl string, target string) (models.TargetContent, error)
+	GetCertificatesInfo(ctx context.Context, tufRepoUrl string) (models.CertificateInfoList, error)
 }
 
 type trustService struct{}
@@ -59,15 +64,118 @@ func (s *trustService) GetTrustRootMetadataInfo(tufRepoUrl string) (models.RootM
 		if err != nil {
 			return models.RootMetadataInfoList{}, fmt.Errorf("extracting root metadata info: %w", err)
 		}
-		entry := models.RootMetadataInfo{
-			Version: rootInfo["version"],
-			Expires: rootInfo["expires"],
-			Status:  rootInfo["status"],
-		}
-		results.Data = append(results.Data, entry)
+		results.Data = append(results.Data, rootInfo)
 	}
 
 	return results, nil
+}
+
+func (s *trustService) GetTargetsList(ctx context.Context, tufRepoUrl string) (models.TargetsList, error) {
+	opts := buildTufOptions(tufRepoUrl)
+	tufCfg, err := buildTufConfig(opts)
+	if err != nil {
+		return models.TargetsList{}, err
+	}
+
+	up, err := updater.New(tufCfg)
+	if err != nil {
+		return models.TargetsList{}, fmt.Errorf("failed to create updater: %w", err)
+	}
+
+	if err := up.Refresh(); err != nil {
+		return models.TargetsList{}, fmt.Errorf("failed to refresh updater: %w", err)
+	}
+
+	// Get Targets list
+	targetFiles := up.GetTopLevelTargets()
+	var targetList []string
+	for target := range targetFiles {
+		targetList = append(targetList, target)
+	}
+
+	return models.TargetsList{Targets: targetList}, nil
+}
+
+func (s *trustService) GetTarget(ctx context.Context, tufRepoUrl string, target string) (models.TargetContent, error) {
+	opts := buildTufOptions(tufRepoUrl)
+	tufCfg, err := buildTufConfig(opts)
+	if err != nil {
+		return models.TargetContent{}, err
+	}
+
+	up, err := updater.New(tufCfg)
+	if err != nil {
+		return models.TargetContent{}, fmt.Errorf("failed to create updater: %w", err)
+	}
+
+	if err := up.Refresh(); err != nil {
+		return models.TargetContent{}, fmt.Errorf("failed to refresh updater: %w", err)
+	}
+
+	// Get Target content
+	const filePath = ""
+	ti, err := up.GetTargetInfo(target)
+	if err != nil {
+		return models.TargetContent{}, fmt.Errorf("getting info for target \"%s\": %w", target, err)
+	}
+	path, tb, err := up.FindCachedTarget(ti, filePath)
+	if err != nil {
+		return models.TargetContent{}, fmt.Errorf("getting target cache: %w", err)
+	}
+	if path != "" {
+		// Cached version found
+		return models.TargetContent{Content: string(tb)}, nil
+	}
+
+	// Download of target is needed
+	// Ignore targetsBaseURL, set to empty string
+	const targetsBaseURL = ""
+	_, tb, err = up.DownloadTarget(ti, filePath, targetsBaseURL)
+	if err != nil {
+		return models.TargetContent{}, fmt.Errorf("failed to download target file %s - %w", target, err)
+	}
+
+	return models.TargetContent{Content: string(tb)}, nil
+}
+
+func (s *trustService) GetCertificatesInfo(ctx context.Context, tufRepoUrl string) (models.CertificateInfoList, error) {
+	opts := buildTufOptions(tufRepoUrl)
+	targetsBytes, err := fetchTufTargetsMetadata(opts)
+	if err != nil {
+		return models.CertificateInfoList{}, fmt.Errorf("fetching TUF target metadata: %w", err)
+	}
+	targetMetadataSpecs, err := extractTargetMetadataInfo(targetsBytes)
+	result := models.CertificateInfoList{}
+	if err != nil {
+		return models.CertificateInfoList{}, fmt.Errorf("fetching TUF root metadata: %w", err)
+	}
+	certificates := []string{}
+	for target, info := range targetMetadataSpecs {
+		// Only targets of type certificate
+		if strings.ToLower(info["type"]) == "fulcio" || strings.ToLower(info["type"]) == "tsa" {
+			certificates = append(certificates, target)
+			cert_content, err := s.GetTarget(ctx, tufRepoUrl, target)
+			if err != nil {
+				return models.CertificateInfoList{}, fmt.Errorf("getting target certificate content: %w", err)
+			}
+			cert_info_list, err := extractCertDetails(cert_content.Content)
+			if err != nil {
+				return models.CertificateInfoList{}, fmt.Errorf("extracting subject and issuer: %w", err)
+			}
+			for _, cert_info := range cert_info_list.Data {
+				result.Data = append(result.Data, models.CertificateInfo{
+					Issuer:     cert_info.Issuer,
+					Subject:    cert_info.Subject,
+					Expiration: cert_info.Expiration,
+					Target:     target,
+					Status:     info["status"],
+					Type:       info["type"],
+				})
+			}
+		}
+	}
+
+	return result, nil
 }
 
 // buildTufOptions returns TUF options with the provided or default repository URL.
@@ -186,8 +294,8 @@ func fetchAllTufRootMetadata(opts *tuf.Options) ([][]byte, error) {
 	return allRootBytes, nil
 }
 
-// Retrieves TUF root metadata info including version, expiration, and status.
-func extractRootMetadataInfo(rootMetadataBytes []byte) (map[string]string, error) {
+// extractRootMetadataInfo retrieves TUF root metadata info including version, expiration, and status.
+func extractRootMetadataInfo(rootMetadataBytes []byte) (models.RootMetadataInfo, error) {
 	var parsed struct {
 		Signed struct {
 			Expired string `json:"expires"`
@@ -196,12 +304,12 @@ func extractRootMetadataInfo(rootMetadataBytes []byte) (map[string]string, error
 	}
 
 	if err := json.Unmarshal(rootMetadataBytes, &parsed); err != nil {
-		return nil, fmt.Errorf("unmarshal targets metadata: %w", err)
+		return models.RootMetadataInfo{}, fmt.Errorf("unmarshal targets metadata: %w", err)
 	}
 
 	expiresTime, err := time.Parse(time.RFC3339, parsed.Signed.Expired)
 	if err != nil {
-		return nil, fmt.Errorf("parse expires time: %w", err)
+		return models.RootMetadataInfo{}, fmt.Errorf("parse expires time: %w", err)
 	}
 
 	now := time.Now().UTC()
@@ -216,11 +324,103 @@ func extractRootMetadataInfo(rootMetadataBytes []byte) (map[string]string, error
 		status = "valid"
 	}
 
-	rootMetadataInfo := map[string]string{
-		"version": strconv.Itoa(parsed.Signed.Version),
-		"expires": parsed.Signed.Expired,
-		"status":  status,
+	rootMetadataInfo := models.RootMetadataInfo{
+		Version: strconv.Itoa(parsed.Signed.Version),
+		Expires: parsed.Signed.Expired,
+		Status:  status,
 	}
 
 	return rootMetadataInfo, nil
+}
+
+// fetchTufTargetsMetadata retrieves TUF target metadata as byte slices.
+func fetchTufTargetsMetadata(opts *tuf.Options) ([]byte, error) {
+	tufCfg, err := buildTufConfig(opts)
+	if err != nil {
+		return nil, err
+	}
+
+	up, err := updater.New(tufCfg)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create updater: %w", err)
+	}
+
+	if err := up.Refresh(); err != nil {
+		return nil, fmt.Errorf("failed to refresh updater: %w", err)
+	}
+
+	// Get raw targets metadata
+	targetsMeta := up.GetTrustedMetadataSet().Targets["targets"]
+	if targetsMeta == nil {
+		return nil, fmt.Errorf("targets metadata not available")
+	}
+
+	targetsBytes, err := targetsMeta.ToBytes(true)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get signed root bytes: %w", err)
+	}
+
+	return targetsBytes, nil
+}
+
+// extractTargetMetadataInfo extracts status & usage of targets
+func extractTargetMetadataInfo(targetsBytes []byte) (map[string]map[string]string, error) {
+	var parsed struct {
+		Signed struct {
+			Targets map[string]struct {
+				Custom struct {
+					Sigstore struct {
+						Status string `json:"status"`
+						Usage  string `json:"usage"`
+					} `json:"sigstore"`
+				} `json:"custom"`
+			} `json:"targets"`
+		} `json:"signed"`
+	}
+
+	if err := json.Unmarshal(targetsBytes, &parsed); err != nil {
+		return nil, fmt.Errorf("unmarshal targets metadata: %w", err)
+	}
+
+	targetSpecs := make(map[string]map[string]string)
+	for name, target := range parsed.Signed.Targets {
+		targetSpecs[name] = map[string]string{
+			"status": target.Custom.Sigstore.Status,
+			"type":   target.Custom.Sigstore.Usage,
+		}
+	}
+
+	return targetSpecs, nil
+}
+
+// extractCertDetails extracts subject, issuer & status from a PEM certificate
+func extractCertDetails(certPEM string) (models.CertificateInfoList, error) {
+	var results models.CertificateInfoList
+	rest := []byte(certPEM)
+	for {
+		block, remaining := pem.Decode(rest)
+		if block == nil {
+			break
+		}
+		rest = remaining
+
+		if block.Type != "CERTIFICATE" {
+			continue
+		}
+		cert, err := x509.ParseCertificate(block.Bytes)
+		if err != nil {
+			return models.CertificateInfoList{}, fmt.Errorf("failed to parse certificate: %w", err)
+		}
+		entry := models.CertificateInfo{
+			Subject:    cert.Subject.String(),
+			Issuer:     cert.Issuer.String(),
+			Expiration: cert.NotAfter.String(),
+		}
+		results.Data = append(results.Data, entry)
+	}
+
+	if len(results.Data) == 0 {
+		return models.CertificateInfoList{}, fmt.Errorf("no valid certificates found")
+	}
+	return results, nil
 }


### PR DESCRIPTION
## Summary by Sourcery

Add support for listing TUF targets, fetching individual target content, and extracting certificate details from TUF repositories.

New Features:
- Introduce TrustService methods GetTargetsList, GetTarget, and GetCertificatesInfo to manage TUF targets and certificates.
- Define new API models for TargetsList, TargetContent, CertificateInfo, and CertificateInfoList.
- Expose HTTP endpoints /trust/targets, /trust/target, and /trust/targets/certificates with handlers, middleware, and updated OpenAPI documentation.

Enhancements:
- Refactor extractRootMetadataInfo to return a typed RootMetadataInfo model.
- Extract common TUF metadata fetching and parsing logic into helper functions for reuse.

Example output:
```
$ curl <CONSOLE_URL>/api/v1/trust/targets/certificates

{
  "data": [
    {
      "expiration": "2031-02-23 03:20:29 +0000 UTC",
      "issuer": "CN=sigstore,O=sigstore.dev",
      "status": "Expired",
      "subject": "CN=sigstore,O=sigstore.dev",
      "target": "fulcio.crt.pem",
      "type": "Fulcio"
    },
    {
      "expiration": "2031-10-05 13:56:58 +0000 UTC",
      "issuer": "CN=sigstore,O=sigstore.dev",
      "status": "Active",
      "subject": "CN=sigstore-intermediate,O=sigstore.dev",
      "target": "fulcio_intermediate_v1.crt.pem",
      "type": "Fulcio"
    },
    {
      "expiration": "2031-10-05 13:56:58 +0000 UTC",
      "issuer": "CN=sigstore,O=sigstore.dev",
      "status": "Active",
      "subject": "CN=sigstore,O=sigstore.dev",
      "target": "fulcio_v1.crt.pem",
      "type": "Fulcio"
    }
  ]
}
```