### PR TITLE
add ./tekton, Dockerfile.rh

### DIFF
--- a/.tekton/rhtas-console-pull-request.yaml
+++ b/.tekton/rhtas-console-pull-request.yaml
@@ -1,0 +1,62 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/securesign/rhtas-console?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    pipelinesascode.tekton.dev/cancel-in-progress: "true"
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "main" &&
+      (".tekton/rhtas-console-pull-request.yaml".pathChanged()
+      || "Dockerfile.rh".pathChanged()
+      || "internal/***".pathChanged() || "cmd/rhtas_console/***".pathChanged()
+      || "go.mod".pathChanged() || "go.sum".pathChanged())
+  creationTimestamp: null
+  labels:
+    appstudio.openshift.io/application: rhtas-console
+    appstudio.openshift.io/component: rhtas-console
+    pipelines.appstudio.openshift.io/type: build
+  name: rhtas-console-on-pull-request
+  namespace: rhtas-tenant
+spec:
+  params:
+  - name: git-url
+    value: '{{source_url}}'
+  - name: revision
+    value: '{{revision}}'
+  - name: output-image
+    value: quay.io/securesign/rhtas-console:on-pr-{{revision}}
+  - name: image-expires-after
+    value: 5d
+  - name: dockerfile
+    value: Dockerfile.rh
+  - name: path-context
+    value: .
+  - name: build-source-image
+    value: "true"
+  - name: hermetic
+    value: "true"
+  - name: prefetch-input
+    value: [{"path": ".", "type": "gomod"}]
+  - name: go_unit_test
+    value: true
+  - name: go_base_image
+    value: registry.redhat.io/ubi9/go-toolset:1.24@sha256:6fd64cd7f38a9b87440f963b6c04953d04de65c35b9672dbd7f1805b0ae20d09
+  pipelineRef:
+    resolver: git
+    params:
+      - name: url
+        value: 'https://github.com/securesign/pipelines.git'
+      - name: revision
+        value: 'main'
+      - name: pathInRepo
+        value: 'pipelines/docker-build-oci-ta.yaml'
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-rhtas-console
+  workspaces:
+  - name: git-auth
+    secret:
+      secretName: '{{ git_auth_secret }}'
+status: {}

--- a/.tekton/rhtas-console-push.yaml
+++ b/.tekton/rhtas-console-push.yaml
@@ -1,0 +1,58 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/securesign/rhtas-console?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    pipelinesascode.tekton.dev/cancel-in-progress: "false"
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "main" &&
+      (".tekton/rhtas-console-push.yaml".pathChanged()
+      || "Dockerfile.rh".pathChanged()
+      || "internal/***".pathChanged() || "cmd/rhtas_console/***".pathChanged()
+      || "go.mod".pathChanged() || "go.sum".pathChanged())
+  creationTimestamp: null
+  labels:
+    appstudio.openshift.io/application: rhtas-console
+    appstudio.openshift.io/component: rhtas-console
+    pipelines.appstudio.openshift.io/type: build
+  name: rhtas-console-on-push
+  namespace: rhtas-tenant
+spec:
+  params:
+  - name: git-url
+    value: '{{source_url}}'
+  - name: revision
+    value: '{{revision}}'
+  - name: output-image
+    value: quay.io/securesign/rhtas-console:{{revision}}
+  - name: dockerfile
+    value: Dockerfile.rh
+  - name: path-context
+    value: .
+  - name: build-source-image
+    value: "true"
+  - name: hermetic
+    value: "true"
+  - name: prefetch-input
+    value: [{"path": ".", "type": "gomod"}]
+  - name: go_unit_test
+    value: true
+  - name: go_base_image
+    value: registry.redhat.io/ubi9/go-toolset:1.24@sha256:6fd64cd7f38a9b87440f963b6c04953d04de65c35b9672dbd7f1805b0ae20d09
+  pipelineRef:
+    resolver: git
+    params:
+      - name: url
+        value: 'https://github.com/securesign/pipelines.git'
+      - name: revision
+        value: 'main'
+      - name: pathInRepo
+        value: 'pipelines/docker-build-oci-ta.yaml'
+  taskRunTemplate: {}
+  workspaces:
+  - name: git-auth
+    secret:
+      secretName: '{{ git_auth_secret }}'
+status: {}

--- a/Dockerfile.rh
+++ b/Dockerfile.rh
@@ -1,0 +1,31 @@
+# Build stage
+FROM registry.redhat.io/ubi9/go-toolset:1.24@sha256:6fd64cd7f38a9b87440f963b6c04953d04de65c35b9672dbd7f1805b0ae20d09 AS builder
+
+WORKDIR /app
+
+COPY . .
+
+RUN go build -buildvcs=false -o rhtas_console ./cmd/rhtas_console
+
+# Final stage
+FROM registry.access.redhat.com/ubi9/ubi-minimal@sha256:67fee1a132e8e326434214b3c7ce90b2500b2ad02c9790cc61581feb58d281d5
+
+COPY --from=builder /app/rhtas_console /rhtas_console
+
+LABEL description="rhtas_console is the backend API server for the Red Hat Trusted Application Signer dashboard."
+LABEL io.k8s.description="Backend API for the Red Hat Trusted Application Signer Console."
+LABEL io.k8s.display-name="RHTAS Console Backend"
+LABEL io.openshift.tags="rhtas backend api trusted-signer"
+LABEL summary="Provides the backend service for RHTAS Console."
+LABEL com.redhat.component="rhtas-console"
+LABEL name="rhtas-console"
+
+COPY LICENSE /licenses/LICENSE
+
+USER 65532:65532
+
+# Expose API port
+EXPOSE 8080
+
+#ENTRYPOINT
+ENTRYPOINT ["/rhtas_console"]


### PR DESCRIPTION
## Summary by Sourcery

Add Tekton CI pipeline configurations and a Dockerfile for automated builds of the rhtas-console application on pull request and push events

New Features:
- Introduce Tekton PipelineRun manifests for automated container builds on pull requests
- Introduce Tekton PipelineRun manifests for automated container builds on push events
- Add Dockerfile.rh for building the rhtas-console image using Red Hat UBI9 Go Toolset

Build:
- Define build parameters (base image, output image tags, context, hermetic builds) in Tekton pipelines

CI:
- Configure pipelinesascode triggers and annotations for pull request and push events