### PR TITLE
Trust: return meaningful status codes and hide internal DB errors

### DIFF
--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -110,7 +110,7 @@ func (h *Handler) GetApiV1TrustConfig(w http.ResponseWriter, r *http.Request) {
 		writeError(w, statusCode, err.Error())
 		return
 	}
-	writeJSON(w, http.StatusOK, resp)
+	writeJSON(w, statusCode, resp)
 }
 
 func (h *Handler) GetApiV1TrustRootMetadata(w http.ResponseWriter, r *http.Request) {
@@ -120,7 +120,7 @@ func (h *Handler) GetApiV1TrustRootMetadata(w http.ResponseWriter, r *http.Reque
 		writeError(w, statusCode, err.Error())
 		return
 	}
-	writeJSON(w, http.StatusOK, resp)
+	writeJSON(w, statusCode, resp)
 }
 
 func (h *Handler) GetApiV1TrustTargets(w http.ResponseWriter, r *http.Request) {
@@ -130,7 +130,7 @@ func (h *Handler) GetApiV1TrustTargets(w http.ResponseWriter, r *http.Request) {
 		writeError(w, statusCode, err.Error())
 		return
 	}
-	writeJSON(w, http.StatusOK, resp)
+	writeJSON(w, statusCode, resp)
 }
 
 func (h *Handler) GetApiV1TrustTarget(w http.ResponseWriter, r *http.Request) {
@@ -141,7 +141,7 @@ func (h *Handler) GetApiV1TrustTarget(w http.ResponseWriter, r *http.Request) {
 		writeError(w, statusCode, err.Error())
 		return
 	}
-	writeJSON(w, http.StatusOK, resp)
+	writeJSON(w, statusCode, resp)
 }
 
 func (h *Handler) GetApiV1TrustTargetsCertificates(w http.ResponseWriter, r *http.Request) {
@@ -151,7 +151,7 @@ func (h *Handler) GetApiV1TrustTargetsCertificates(w http.ResponseWriter, r *htt
 		writeError(w, statusCode, err.Error())
 		return
 	}
-	writeJSON(w, http.StatusOK, resp)
+	writeJSON(w, statusCode, resp)
 }
 
 func (h *Handler) ServeSwaggerUI(w http.ResponseWriter, r *http.Request) {

--- a/internal/services/trust.go
+++ b/internal/services/trust.go
@@ -38,11 +38,11 @@ var (
 )
 
 type TrustService interface {
-	GetTrustConfig(ctx context.Context, tufRepoUrl string) (models.TrustConfig, error, int)
-	GetTrustRootMetadataInfo(tufRepoUrl string) (models.RootMetadataInfoList, error, int)
-	GetTarget(ctx context.Context, tufRepoUrl string, target string) (models.TargetContent, error, int)
-	GetCertificatesInfo(ctx context.Context, tufRepoUrl string) (models.CertificateInfoList, error, int)
-	GetAllTargets(ctx context.Context, tufRepoUrl string) (models.TargetsList, error, int)
+	GetTrustConfig(ctx context.Context, tufRepoUrl string) (cfg models.TrustConfig, err error, statusCode int)
+	GetTrustRootMetadataInfo(tufRepoUrl string) (info models.RootMetadataInfoList, err error, statusCode int)
+	GetTarget(ctx context.Context, tufRepoUrl string, target string) (content models.TargetContent, err error, statusCode int)
+	GetCertificatesInfo(ctx context.Context, tufRepoUrl string) (certs models.CertificateInfoList, err error, statusCode int)
+	GetAllTargets(ctx context.Context, tufRepoUrl string) (targets models.TargetsList, err error, statusCode int)
 	CloseDB() error
 }
 


### PR DESCRIPTION
## Summary by Sourcery

Revamp TrustService to return HTTP status codes and conceal internal errors behind generic messages

Enhancements:
- Extend TrustService methods to include an HTTP status code return value
- Map different failures to meaningful HTTP status codes (e.g. 200, 404, 503, 499, 504)
- Log internal database and TUF errors while returning generic user-facing error messages
- Update HTTP handlers to propagate the status codes returned by the service