### PR TITLE
add trigger action

### DIFF
--- a/.github/workflows/trigger-konflux-build.yaml
+++ b/.github/workflows/trigger-konflux-build.yaml
@@ -1,0 +1,11 @@
+name: Trigger Konflux build
+on:
+  workflow_dispatch:
+
+jobs:
+  trigger-konflux-build:
+    uses: securesign/actions/.github/workflows/trigger-konflux-build.yaml@main
+    with:
+      branch: main
+    secrets:
+      token: ${{ secrets.GITHUB_TOKEN }}

--- a/.tekton/rhtas-console-pull-request.yaml
+++ b/.tekton/rhtas-console-pull-request.yaml
@@ -12,7 +12,7 @@ metadata:
       (".tekton/rhtas-console-pull-request.yaml".pathChanged()
       || "Dockerfile.rh".pathChanged()
       || "internal/***".pathChanged() || "cmd/rhtas_console/***".pathChanged()
-      || "go.mod".pathChanged() || "go.sum".pathChanged())
+      || "go.mod".pathChanged() || "go.sum".pathChanged() || "trigger-konflux-builds.txt".pathChanged())
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: rhtas-console

--- a/.tekton/rhtas-console-push.yaml
+++ b/.tekton/rhtas-console-push.yaml
@@ -11,7 +11,7 @@ metadata:
       (".tekton/rhtas-console-push.yaml".pathChanged()
       || "Dockerfile.rh".pathChanged()
       || "internal/***".pathChanged() || "cmd/rhtas_console/***".pathChanged()
-      || "go.mod".pathChanged() || "go.sum".pathChanged())
+      || "go.mod".pathChanged() || "go.sum".pathChanged() || "trigger-konflux-builds.txt".pathChanged())
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: rhtas-console


### PR DESCRIPTION
## Summary by Sourcery

Add a manual trigger for Konflux builds and update Tekton pipeline triggers to include the trigger file.

Enhancements:
- Include trigger-konflux-builds.txt in pathChanged filters for both PR and push Tekton pipelines

CI:
- Introduce a GitHub Actions workflow to manually trigger Konflux builds via a reusable workflow