### PR TITLE
Simplify trust coverage API to attestation-only schema

### DIFF
--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -141,23 +141,7 @@ func (h *Handler) GetApiV1TrustTargetsCertificates(w http.ResponseWriter, r *htt
 }
 
 func (h *Handler) GetApiV1TrustCoverage(w http.ResponseWriter, r *http.Request) {
-	timeWindow := r.URL.Query().Get("timeWindow")
-	if timeWindow == "" {
-		timeWindow = "7d"
-	}
-
-	environmentParam := r.URL.Query().Get("environment")
-	var environment *string
-	if environmentParam != "" {
-		environment = &environmentParam
-	}
-
-	tufRepoUrl := r.URL.Query().Get("tufRepositoryUrl")
-	if tufRepoUrl == "" {
-		tufRepoUrl = os.Getenv("TUF_REPO_URL")
-	}
-
-	resp, statusCode, err := h.trustService.GetTrustCoverage(r.Context(), timeWindow, environment, tufRepoUrl)
+	resp, statusCode, err := h.trustService.GetTrustCoverage(r.Context())
 	if err != nil {
 		writeError(w, statusCode, err.Error())
 		return

--- a/internal/api/openapi/rhtas-console.yaml
+++ b/internal/api/openapi/rhtas-console.yaml
@@ -367,34 +367,11 @@ paths:
     get:
       summary: Get Trust Coverage
       description: |
-        Returns aggregated signing and verification posture data across environments.
-        Supports filtering by time window and deployment environment.
+        Returns attestation coverage for artifacts already processed by TAS.
+        This endpoint is intentionally limited in scope and does not imply coverage
+        of all artifacts in a registry, cluster, environment, or across multiple clusters.
       tags:
         - Trust
-      parameters:
-        - name: timeWindow
-          in: query
-          required: false
-          schema:
-            type: string
-            description: Time window for filtering coverage data
-            enum: [24h, 7d, 30d, 90d, all]
-            default: 7d
-            example: 7d
-        - name: environment
-          in: query
-          required: false
-          schema:
-            type: string
-            description: Deployment environment filter (e.g., production, staging, development)
-            example: production
-        - name: tufRepositoryUrl
-          in: query
-          required: false
-          schema:
-            type: string
-            description: URL of the TUF repository
-            example: https://tuf-repo-cdn.sigstore.dev/
       responses:
         "200":
           description: Trust coverage data
@@ -403,62 +380,11 @@ paths:
               schema:
                 $ref: "#/components/schemas/TrustCoverageResponse"
               example:
-                totals:
-                  totalArtifacts: 1000
-                  signedArtifacts: 845
-                  verifiedArtifacts: 795
-                  attestedArtifacts: 610
-                  rekorEntries: 845
-                percentages:
-                  signedPercentage: 84.5
-                  verifiedPercentage: 79.5
-                  attestedPercentage: 61.0
-                environmentBreakdown:
-                  - environment: production
-                    totals:
-                      totalArtifacts: 500
-                      signedArtifacts: 475
-                      verifiedArtifacts: 450
-                      attestedArtifacts: 400
-                      rekorEntries: 475
-                    percentages:
-                      signedPercentage: 95.0
-                      verifiedPercentage: 90.0
-                      attestedPercentage: 80.0
-                  - environment: staging
-                    totals:
-                      totalArtifacts: 300
-                      signedArtifacts: 240
-                      verifiedArtifacts: 225
-                      attestedArtifacts: 150
-                      rekorEntries: 240
-                    percentages:
-                      signedPercentage: 80.0
-                      verifiedPercentage: 75.0
-                      attestedPercentage: 50.0
-                  - environment: development
-                    totals:
-                      totalArtifacts: 200
-                      signedArtifacts: 130
-                      verifiedArtifacts: 120
-                      attestedArtifacts: 60
-                      rekorEntries: 130
-                    percentages:
-                      signedPercentage: 65.0
-                      verifiedPercentage: 60.0
-                      attestedPercentage: 30.0
-                trendData: []
-                appliedFilters:
-                  timeWindow: 7d
-                  environment: null
-                  tufRepositoryUrl: https://tuf-repo-cdn.sigstore.dev
-                generatedAt: "2024-03-10T15:30:00Z"
-        "400":
-          description: Invalid input
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Error"
+                totalArtifacts: 1000
+                attestedCount: 610
+                unattestedCount: 390
+                attestationPercentage: 61.0
+                updatedAt: "2024-03-10T15:30:00Z"
         "500":
           description: Internal server error
           content:
@@ -1151,171 +1077,32 @@ components:
     TrustCoverageResponse:
       type: object
       properties:
-        totals:
-          $ref: "#/components/schemas/CoverageTotals"
-          description: Aggregate coverage totals across all environments
-        percentages:
-          $ref: "#/components/schemas/CoveragePercentages"
-          description: Coverage percentages across all environments
-        environmentBreakdown:
-          type: array
-          description: Coverage breakdown by deployment environment
-          items:
-            $ref: "#/components/schemas/EnvironmentCoverage"
-        trendData:
-          type: array
-          description: Historical trend data for coverage metrics
-          items:
-            $ref: "#/components/schemas/TrendDataPoint"
-          default: []
-        appliedFilters:
-          $ref: "#/components/schemas/AppliedCoverageFilters"
-          description: The filters that were applied to generate this coverage data
-        generatedAt:
-          type: string
-          format: date-time
-          description: Timestamp when the coverage report was generated
-      required:
-        - totals
-        - percentages
-        - environmentBreakdown
-        - trendData
-        - appliedFilters
-        - generatedAt
-    AppliedCoverageFilters:
-      type: object
-      properties:
-        timeWindow:
-          type: string
-          description: Time window that was applied
-          example: 7d
-        environment:
-          type: string
-          nullable: true
-          description: Environment filter that was applied (null if not filtered)
-          example: production
-        tufRepositoryUrl:
-          type: string
-          description: TUF repository URL that was used as the data source
-          example: https://tuf-repo-cdn.sigstore.dev
-      required:
-        - timeWindow
-        - tufRepositoryUrl
-    CoverageTotals:
-      type: object
-      properties:
         totalArtifacts:
           type: integer
-          description: Total number of artifacts
+          description: Total number of artifacts processed by TAS
           example: 1000
-        signedArtifacts:
-          type: integer
-          description: Number of signed artifacts
-          example: 850
-        verifiedArtifacts:
-          type: integer
-          description: Number of verified artifacts
-          example: 800
-        attestedArtifacts:
-          type: integer
-          description: Number of artifacts with attestations
-          example: 600
-        rekorEntries:
-          type: integer
-          description: Total number of Rekor transparency log entries
-          example: 850
-      required:
-        - totalArtifacts
-        - signedArtifacts
-        - verifiedArtifacts
-        - attestedArtifacts
-        - rekorEntries
-    CoveragePercentages:
-      type: object
-      properties:
-        signedPercentage:
-          type: number
-          format: float
-          description: Percentage of artifacts that are signed
-          minimum: 0
-          maximum: 100
-          example: 85.0
-        verifiedPercentage:
-          type: number
-          format: float
-          description: Percentage of artifacts that are verified
-          minimum: 0
-          maximum: 100
-          example: 80.0
-        attestedPercentage:
-          type: number
-          format: float
-          description: Percentage of artifacts with attestations
-          minimum: 0
-          maximum: 100
-          example: 60.0
-      required:
-        - signedPercentage
-        - verifiedPercentage
-        - attestedPercentage
-    EnvironmentCoverage:
-      type: object
-      properties:
-        environment:
-          type: string
-          description: Environment name
-          example: production
-        totals:
-          $ref: "#/components/schemas/CoverageTotals"
-        percentages:
-          $ref: "#/components/schemas/CoveragePercentages"
-      required:
-        - environment
-        - totals
-        - percentages
-    TrendDataPoint:
-      type: object
-      properties:
-        timestamp:
-          type: string
-          format: date-time
-          description: Time point
-        totalArtifacts:
-          type: integer
-          description: Total number of artifacts at this time point
-        signedCount:
-          type: integer
-          description: Number of signed artifacts at this time point
-        verifiedCount:
-          type: integer
-          description: Number of verified artifacts at this time point
         attestedCount:
           type: integer
-          description: Number of attested artifacts at this time point
-        signedPercentage:
+          description: Number of attested artifacts
+          example: 610
+        unattestedCount:
+          type: integer
+          description: Number of unattested artifacts
+          example: 390
+        attestationPercentage:
           type: number
           format: float
-          description: Percentage of artifacts that are signed at this time point
+          description: Percentage of artifacts that are attested
           minimum: 0
           maximum: 100
-        verifiedPercentage:
-          type: number
-          format: float
-          description: Percentage of artifacts that are verified at this time point
-          minimum: 0
-          maximum: 100
-        attestedPercentage:
-          type: number
-          format: float
-          description: Percentage of artifacts with attestations at this time point
-          minimum: 0
-          maximum: 100
+          example: 61.0
+        updatedAt:
+          type: string
+          format: date-time
+          description: Timestamp when the coverage data was last updated
       required:
-        - timestamp
         - totalArtifacts
-        - signedCount
-        - verifiedCount
         - attestedCount
-        - signedPercentage
-        - verifiedPercentage
-        - attestedPercentage
+        - unattestedCount
+        - attestationPercentage
+        - updatedAt

--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -83,27 +83,6 @@ const (
 	Verified SignatureStatusSignature = "verified"
 )
 
-// Defines values for GetApiV1TrustCoverageParamsTimeWindow.
-const (
-	All  GetApiV1TrustCoverageParamsTimeWindow = "all"
-	N24h GetApiV1TrustCoverageParamsTimeWindow = "24h"
-	N30d GetApiV1TrustCoverageParamsTimeWindow = "30d"
-	N7d  GetApiV1TrustCoverageParamsTimeWindow = "7d"
-	N90d GetApiV1TrustCoverageParamsTimeWindow = "90d"
-)
-
-// AppliedCoverageFilters defines model for AppliedCoverageFilters.
-type AppliedCoverageFilters struct {
-	// Environment Environment filter that was applied (null if not filtered)
-	Environment *string `json:"environment"`
-
-	// TimeWindow Time window that was applied
-	TimeWindow string `json:"timeWindow"`
-
-	// TufRepositoryUrl TUF repository URL that was used as the data source
-	TufRepositoryUrl string `json:"tufRepositoryUrl"`
-}
-
 // ArtifactIdentity defines model for ArtifactIdentity.
 type ArtifactIdentity struct {
 	// Id Unique identifier for the signature view
@@ -219,44 +198,6 @@ type CertificateRole string
 // Checkpoint defines model for Checkpoint.
 type Checkpoint struct {
 	Envelope string `json:"envelope"`
-}
-
-// CoveragePercentages defines model for CoveragePercentages.
-type CoveragePercentages struct {
-	// AttestedPercentage Percentage of artifacts with attestations
-	AttestedPercentage float32 `json:"attestedPercentage"`
-
-	// SignedPercentage Percentage of artifacts that are signed
-	SignedPercentage float32 `json:"signedPercentage"`
-
-	// VerifiedPercentage Percentage of artifacts that are verified
-	VerifiedPercentage float32 `json:"verifiedPercentage"`
-}
-
-// CoverageTotals defines model for CoverageTotals.
-type CoverageTotals struct {
-	// AttestedArtifacts Number of artifacts with attestations
-	AttestedArtifacts int `json:"attestedArtifacts"`
-
-	// RekorEntries Total number of Rekor transparency log entries
-	RekorEntries int `json:"rekorEntries"`
-
-	// SignedArtifacts Number of signed artifacts
-	SignedArtifacts int `json:"signedArtifacts"`
-
-	// TotalArtifacts Total number of artifacts
-	TotalArtifacts int `json:"totalArtifacts"`
-
-	// VerifiedArtifacts Number of verified artifacts
-	VerifiedArtifacts int `json:"verifiedArtifacts"`
-}
-
-// EnvironmentCoverage defines model for EnvironmentCoverage.
-type EnvironmentCoverage struct {
-	// Environment Environment name
-	Environment string              `json:"environment"`
-	Percentages CoveragePercentages `json:"percentages"`
-	Totals      CoverageTotals      `json:"totals"`
 }
 
 // Error defines model for Error.
@@ -435,33 +376,6 @@ type TransparencyLogEntry struct {
 	LogIndex       int64           `json:"logIndex"`
 }
 
-// TrendDataPoint defines model for TrendDataPoint.
-type TrendDataPoint struct {
-	// AttestedCount Number of attested artifacts at this time point
-	AttestedCount int `json:"attestedCount"`
-
-	// AttestedPercentage Percentage of artifacts with attestations at this time point
-	AttestedPercentage float32 `json:"attestedPercentage"`
-
-	// SignedCount Number of signed artifacts at this time point
-	SignedCount int `json:"signedCount"`
-
-	// SignedPercentage Percentage of artifacts that are signed at this time point
-	SignedPercentage float32 `json:"signedPercentage"`
-
-	// Timestamp Time point
-	Timestamp time.Time `json:"timestamp"`
-
-	// TotalArtifacts Total number of artifacts at this time point
-	TotalArtifacts int `json:"totalArtifacts"`
-
-	// VerifiedCount Number of verified artifacts at this time point
-	VerifiedCount int `json:"verifiedCount"`
-
-	// VerifiedPercentage Percentage of artifacts that are verified at this time point
-	VerifiedPercentage float32 `json:"verifiedPercentage"`
-}
-
 // TrustConfig defines model for TrustConfig.
 type TrustConfig struct {
 	FulcioCertAuthorities []struct {
@@ -475,18 +389,20 @@ type TrustConfig struct {
 
 // TrustCoverageResponse defines model for TrustCoverageResponse.
 type TrustCoverageResponse struct {
-	AppliedFilters AppliedCoverageFilters `json:"appliedFilters"`
+	// AttestationPercentage Percentage of artifacts that are attested
+	AttestationPercentage float32 `json:"attestationPercentage"`
 
-	// EnvironmentBreakdown Coverage breakdown by deployment environment
-	EnvironmentBreakdown []EnvironmentCoverage `json:"environmentBreakdown"`
+	// AttestedCount Number of attested artifacts
+	AttestedCount int `json:"attestedCount"`
 
-	// GeneratedAt Timestamp when the coverage report was generated
-	GeneratedAt time.Time           `json:"generatedAt"`
-	Percentages CoveragePercentages `json:"percentages"`
-	Totals      CoverageTotals      `json:"totals"`
+	// TotalArtifacts Total number of artifacts processed by TAS
+	TotalArtifacts int `json:"totalArtifacts"`
 
-	// TrendData Historical trend data for coverage metrics
-	TrendData []TrendDataPoint `json:"trendData"`
+	// UnattestedCount Number of unattested artifacts
+	UnattestedCount int `json:"unattestedCount"`
+
+	// UpdatedAt Timestamp when the coverage data was last updated
+	UpdatedAt time.Time `json:"updatedAt"`
 }
 
 // VerifyArtifactRequest Parameters for verifying a signed artifact or container image using Sigstore and related trust sources. Fields correspond to common verification inputs such as issuer expectations, trusted roots, and TUF configuration.
@@ -588,16 +504,6 @@ type GetApiV1TrustConfigParams struct {
 	TufRepositoryUrl *string `form:"tufRepositoryUrl,omitempty" json:"tufRepositoryUrl,omitempty"`
 }
 
-// GetApiV1TrustCoverageParams defines parameters for GetApiV1TrustCoverage.
-type GetApiV1TrustCoverageParams struct {
-	TimeWindow       *GetApiV1TrustCoverageParamsTimeWindow `form:"timeWindow,omitempty" json:"timeWindow,omitempty"`
-	Environment      *string                                `form:"environment,omitempty" json:"environment,omitempty"`
-	TufRepositoryUrl *string                                `form:"tufRepositoryUrl,omitempty" json:"tufRepositoryUrl,omitempty"`
-}
-
-// GetApiV1TrustCoverageParamsTimeWindow defines parameters for GetApiV1TrustCoverage.
-type GetApiV1TrustCoverageParamsTimeWindow string
-
 // GetApiV1TrustRootMetadataInfoParams defines parameters for GetApiV1TrustRootMetadataInfo.
 type GetApiV1TrustRootMetadataInfoParams struct {
 	TufRepositoryUrl *string `form:"tufRepositoryUrl,omitempty" json:"tufRepositoryUrl,omitempty"`
@@ -644,7 +550,7 @@ type ServerInterface interface {
 	GetApiV1TrustConfig(w http.ResponseWriter, r *http.Request, params GetApiV1TrustConfigParams)
 	// Get Trust Coverage
 	// (GET /api/v1/trust/coverage)
-	GetApiV1TrustCoverage(w http.ResponseWriter, r *http.Request, params GetApiV1TrustCoverageParams)
+	GetApiV1TrustCoverage(w http.ResponseWriter, r *http.Request)
 	// Get TUF Root Metadata
 	// (GET /api/v1/trust/root-metadata-info)
 	GetApiV1TrustRootMetadataInfo(w http.ResponseWriter, r *http.Request, params GetApiV1TrustRootMetadataInfoParams)
@@ -704,7 +610,7 @@ func (_ Unimplemented) GetApiV1TrustConfig(w http.ResponseWriter, r *http.Reques
 
 // Get Trust Coverage
 // (GET /api/v1/trust/coverage)
-func (_ Unimplemented) GetApiV1TrustCoverage(w http.ResponseWriter, r *http.Request, params GetApiV1TrustCoverageParams) {
+func (_ Unimplemented) GetApiV1TrustCoverage(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusNotImplemented)
 }
 
@@ -894,37 +800,8 @@ func (siw *ServerInterfaceWrapper) GetApiV1TrustConfig(w http.ResponseWriter, r 
 // GetApiV1TrustCoverage operation middleware
 func (siw *ServerInterfaceWrapper) GetApiV1TrustCoverage(w http.ResponseWriter, r *http.Request) {
 
-	var err error
-
-	// Parameter object where we will unmarshal all parameters from the context
-	var params GetApiV1TrustCoverageParams
-
-	// ------------- Optional query parameter "timeWindow" -------------
-
-	err = runtime.BindQueryParameter("form", true, false, "timeWindow", r.URL.Query(), &params.TimeWindow)
-	if err != nil {
-		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "timeWindow", Err: err})
-		return
-	}
-
-	// ------------- Optional query parameter "environment" -------------
-
-	err = runtime.BindQueryParameter("form", true, false, "environment", r.URL.Query(), &params.Environment)
-	if err != nil {
-		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "environment", Err: err})
-		return
-	}
-
-	// ------------- Optional query parameter "tufRepositoryUrl" -------------
-
-	err = runtime.BindQueryParameter("form", true, false, "tufRepositoryUrl", r.URL.Query(), &params.TufRepositoryUrl)
-	if err != nil {
-		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "tufRepositoryUrl", Err: err})
-		return
-	}
-
 	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		siw.Handler.GetApiV1TrustCoverage(w, r, params)
+		siw.Handler.GetApiV1TrustCoverage(w, r)
 	}))
 
 	for _, middleware := range siw.HandlerMiddlewares {

--- a/internal/services/trust.go
+++ b/internal/services/trust.go
@@ -45,7 +45,7 @@ type TrustService interface {
 	GetTarget(ctx context.Context, tufRepoUrl string, target string) (content models.TargetContent, statusCode int, err error)
 	GetCertificatesInfo(ctx context.Context, tufRepoUrl string) (certs models.CertificateInfoList, statusCode int, err error)
 	GetAllTargets(ctx context.Context, tufRepoUrl string) (targets models.TargetsList, statusCode int, err error)
-	GetTrustCoverage(ctx context.Context, timeWindow string, environment *string, tufRepoUrl string) (coverage models.TrustCoverageResponse, statusCode int, err error)
+	GetTrustCoverage(ctx context.Context) (coverage models.TrustCoverageResponse, statusCode int, err error)
 	CloseDB() error
 }
 
@@ -333,152 +333,26 @@ func (s *trustService) GetAllTargets(ctx context.Context, tufRepoUrl string) (mo
 	return result, http.StatusOK, nil
 }
 
-func (s *trustService) GetTrustCoverage(ctx context.Context, timeWindow string, environment *string, tufRepoUrl string) (models.TrustCoverageResponse, int, error) {
+func (s *trustService) GetTrustCoverage(ctx context.Context) (models.TrustCoverageResponse, int, error) {
 	mockMode := os.Getenv("MOCK_MODE")
 	if mockMode != "true" {
 		return models.TrustCoverageResponse{}, http.StatusServiceUnavailable, fmt.Errorf("coverage data not available - set MOCK_MODE=true for mock data")
 	}
 
-	if timeWindow == "" {
-		timeWindow = "7d"
-	}
-
-	validTimeWindows := map[string]bool{
-		"24h": true,
-		"7d":  true,
-		"30d": true,
-		"90d": true,
-		"all": true,
-	}
-	if !validTimeWindows[timeWindow] {
-		return models.TrustCoverageResponse{}, http.StatusBadRequest, fmt.Errorf("invalid time window: %s (valid values: 24h, 7d, 30d, 90d, all)", timeWindow)
-	}
-
-	return getMockTrustCoverage(timeWindow, environment, tufRepoUrl), http.StatusOK, nil
+	return getMockTrustCoverage(), http.StatusOK, nil
 }
 
-func getMockTrustCoverage(timeWindow string, environment *string, tufRepoUrl string) models.TrustCoverageResponse {
-	// define mock data for each environment
-	prodTotals := models.CoverageTotals{
-		TotalArtifacts:     500,
-		SignedArtifacts:    475,
-		VerifiedArtifacts:  450,
-		AttestedArtifacts:  400,
-		RekorEntries:       475,
-	}
-
-	prodPercentages := models.CoveragePercentages{
-		SignedPercentage:    95.0,
-		VerifiedPercentage:  90.0,
-		AttestedPercentage:  80.0,
-	}
-
-	stagingTotals := models.CoverageTotals{
-		TotalArtifacts:     300,
-		SignedArtifacts:    240,
-		VerifiedArtifacts:  225,
-		AttestedArtifacts:  150,
-		RekorEntries:       240,
-	}
-
-	stagingPercentages := models.CoveragePercentages{
-		SignedPercentage:    80.0,
-		VerifiedPercentage:  75.0,
-		AttestedPercentage:  50.0,
-	}
-
-	devTotals := models.CoverageTotals{
-		TotalArtifacts:     200,
-		SignedArtifacts:    130,
-		VerifiedArtifacts:  120,
-		AttestedArtifacts:  60,
-		RekorEntries:       130,
-	}
-	
-	devPercentages := models.CoveragePercentages{
-		SignedPercentage:    65.0,
-		VerifiedPercentage:  60.0,
-		AttestedPercentage:  30.0,
-	}
-
-	// build environment breakdown
-	allEnvironments := []models.EnvironmentCoverage{
-		{
-			Environment: "production",
-			Totals:      prodTotals,
-			Percentages: prodPercentages,
-		},
-		{
-			Environment: "staging",
-			Totals:      stagingTotals,
-			Percentages: stagingPercentages,
-		},
-		{
-			Environment: "development",
-			Totals:      devTotals,
-			Percentages: devPercentages,
-		},
-	}
-
-	// filter by environment
-	var environmentBreakdown []models.EnvironmentCoverage
-	var aggregateTotals models.CoverageTotals
-	var aggregatePercentages models.CoveragePercentages
-
-	if environment != nil && *environment != "" {
-		for _, env := range allEnvironments {
-			if env.Environment == *environment {
-				environmentBreakdown = append(environmentBreakdown, env)
-				aggregateTotals = env.Totals
-				aggregatePercentages = env.Percentages
-				break
-			}
-		}
-
-		if len(environmentBreakdown) == 0 {
-			environmentBreakdown = []models.EnvironmentCoverage{}
-			aggregateTotals = models.CoverageTotals{
-				TotalArtifacts:     0,
-				SignedArtifacts:    0,
-				VerifiedArtifacts:  0,
-				AttestedArtifacts:  0,
-				RekorEntries:       0,
-			}
-			aggregatePercentages = models.CoveragePercentages{
-				SignedPercentage:    0.0,
-				VerifiedPercentage:  0.0,
-				AttestedPercentage:  0.0,
-			}
-		}
-	} else {
-		environmentBreakdown = allEnvironments
-
-		aggregateTotals = models.CoverageTotals{
-			TotalArtifacts:     1000,
-			SignedArtifacts:    845,
-			VerifiedArtifacts:  795,
-			AttestedArtifacts:  610,
-			RekorEntries:       845,
-		}
-
-		aggregatePercentages = models.CoveragePercentages{
-			SignedPercentage:    84.5,
-			VerifiedPercentage:  79.5,
-			AttestedPercentage:  61.0,
-		}
-	}
+func getMockTrustCoverage() models.TrustCoverageResponse {
+	totalArtifacts := 1000
+	attestedCount := 610
+	unattestedCount := totalArtifacts - attestedCount
 
 	return models.TrustCoverageResponse{
-		Totals:               aggregateTotals,
-		Percentages:          aggregatePercentages,
-		EnvironmentBreakdown: environmentBreakdown,
-		TrendData:            []models.TrendDataPoint{},
-		AppliedFilters: models.AppliedCoverageFilters{
-			TimeWindow:       timeWindow,
-			Environment:      environment,
-			TufRepositoryUrl: tufRepoUrl,
-		},
-		GeneratedAt: time.Now().UTC(),
+		TotalArtifacts:        totalArtifacts,
+		AttestedCount:         attestedCount,
+		UnattestedCount:       unattestedCount,
+		AttestationPercentage: float32(attestedCount) / float32(totalArtifacts) * 100,
+		UpdatedAt:             time.Now().UTC(),
 	}
 }
 


### PR DESCRIPTION
## Summary
- Simplified `GET /api/v1/trust/coverage` to return a flat response with `totalArtifacts`, `attestedCount`, `unattestedCount`, `attestationPercentage`, and `updatedAt`
- Removed all query parameters (`timeWindow`, `environment`, `tufRepositoryUrl`) — the endpoint no longer supports filtering by environment or time window
- Removed 5 now-unused OpenAPI schemas (`CoverageTotals`, `CoveragePercentages`, `EnvironmentCoverage`, `TrendDataPoint`, `AppliedCoverageFilters`) and their generated Go types
- Mock response still gated behind `MOCK_MODE=true`

This aligns the API contract with the updated acceptance criteria: the Console displays attestation coverage for artifacts already processed by TAS, without implying coverage across registries, clusters, or environments.

## Test plan
- [ ] Run with `MOCK_MODE=true` and verify `GET /api/v1/trust/coverage` returns the simplified flat response
- [ ] Verify the response contains all 5 required fields: `totalArtifacts`, `attestedCount`, `unattestedCount`, `attestationPercentage`, `updatedAt`
- [ ] Verify no query parameters are accepted or processed
- [ ] Run without `MOCK_MODE` and confirm 503 is returned
- [ ] Confirm `go build ./...` passes cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)