### PR TITLE
fix(ci): replace Codecov token auth with OIDC and update action versions

### DIFF
--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -8,18 +8,22 @@ on:
 jobs:
   coverage:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Install Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version-file: 'go.mod'
       - name: Run tests with coverage
         run: go test -coverprofile=coverage.out ./...
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v6
         with:
           files: coverage.out
-          token: ${{ secrets.CODECOV_TOKEN }}
+          use_oidc: true
+          flags: unit-tests
           fail_ci_if_error: false

--- a/codecov.yml
+++ b/codecov.yml
@@ -8,3 +8,7 @@ coverage:
       default:
         target: 70%
         threshold: 5%
+
+flags:
+  unit-tests:
+    carryforward: true


### PR DESCRIPTION
## Summary

- Replace legacy `CODECOV_TOKEN` secret authentication with OIDC (`use_oidc: true`) for Codecov uploads
- Add `id-token: write` and `contents: read` permissions to the coverage job
- Bump `actions/checkout` from v4 to v6, `actions/setup-go` from v5 to v6, and `codecov/codecov-action` from v5 to v6
- Add `unit-tests` flag to coverage uploads in the workflow
- Define `unit-tests` flag with `carryforward: true` in `codecov.yml` (no path restriction, covers entire repo)

Implements [SECURESIGN-4437](https://redhat.atlassian.net/browse/SECURESIGN-4437)

Epic: [COVERPORT-197](https://redhat.atlassian.net/browse/COVERPORT-197)

## Test plan

- [x] Verify the code-coverage workflow runs successfully on PR creation
- [x] Confirm OIDC authentication works (no token-related errors in Codecov upload step)
- [x] Check coverage uploads appear at https://app.codecov.io/gh/securesign/rhtas-console
- [x] Verify PR coverage comments show `unit-tests` flag breakdown
- [ ] Confirm no duplicate or miscategorized coverage uploads

🤖 Generated with [Claude Code](https://claude.com/claude-code)