### PR TITLE
Fips work

### DIFF
--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -19,9 +19,6 @@ jobs:
         with:
           go-version-file: 'go.mod'
 
-      - name: Remove RHTAS FIPS godebug for upstream Go # RHTAS FIPS - DO NOT REMOVE
-        run: go mod edit -dropgodebug=fips140
-
       - name: Run tests with coverage
         run: go test -coverprofile=coverage.out ./...
       - name: Upload coverage to Codecov

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 bin/*
+rhtas_console
 coverage.out

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,8 @@ WORKDIR /app
 
 COPY . .
 
-RUN GOFIPS140=v1.0.0 go build -tags=no_openssl -buildvcs=false -o rhtas_console ./cmd/rhtas_console
+RUN go mod edit -godebug=fips140=auto && \
+    GOFIPS140=v1.0.0 go build -tags=no_openssl -buildvcs=false -o rhtas_console ./cmd/rhtas_console
 
 # Final stage
 FROM registry.access.redhat.com/ubi9/ubi-minimal:9.8-1782797275

--- a/Dockerfile.rh
+++ b/Dockerfile.rh
@@ -3,9 +3,12 @@ FROM registry.redhat.io/ubi9/go-toolset:9.8-1784076237@sha256:dba8f7f9cc231f4729
 
 WORKDIR /app
 
+USER root
+
 COPY . .
 
-RUN GOFIPS140=v1.0.0 go build -tags=no_openssl -buildvcs=false -o rhtas_console ./cmd/rhtas_console
+RUN go mod edit -godebug=fips140=auto && \
+    GOFIPS140=v1.0.0 go build -tags=no_openssl -buildvcs=false -o rhtas_console ./cmd/rhtas_console
 
 # Final stage
 FROM registry.access.redhat.com/ubi9/ubi-minimal@sha256:463cae32c6f6f5594b11a5c22de275016bd8545ce58a6373388e8b24f13fc15c

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,6 @@ build: generate-openapi deps
 .PHONY: run
 run: build
 	@echo "Running $(BINARY_NAME)..."
-	@GODEBUG=fips140=off \
 	"./$(BUILD_DIR)/$(BINARY_NAME)" \
 		--tuf-repo-url="$(TUF_PUBLIC_INSTANCE)"
 
@@ -36,12 +35,12 @@ deps:
 .PHONY: test
 test:
 	@echo "Running tests..."
-	GODEBUG=fips140=off go test ./...
+	go test ./...
 
 .PHONY: coverage
 coverage:
 	@echo "Running tests with coverage..."
-	GODEBUG=fips140=off go test -coverprofile=coverage.out ./...
+	go test -coverprofile=coverage.out ./...
 	go tool cover -func=coverage.out
 
 .PHONY: clean

--- a/go.mod
+++ b/go.mod
@@ -2,8 +2,6 @@ module github.com/securesign/rhtas-console
 
 go 1.26.0
 
-godebug fips140=auto
-
 require (
 	github.com/go-chi/chi/v5 v5.3.0
 	github.com/google/go-containerregistry v0.21.6


### PR DESCRIPTION
## Summary
- Remove `godebug fips140=auto` from `go.mod` so the repo works
  with stock Go on non-FIPS hosts without overrides
- Inject `go mod edit -godebug=fips140=auto` in `Dockerfile` and
  `Dockerfile.rh` at build time, keeping the same FIPS posture in
  production images
- Remove the `GODEBUG=fips140=off` workarounds from Makefile
  `run`/`test`/`coverage` targets
- Remove the `go mod edit -dropgodebug=fips140` CI workaround step
  from the code-coverage workflow
