### PR TITLE
feat: enrich certificates API with validFor service windows from trusted_root.json

### DIFF
--- a/internal/api/openapi/rhtas-console.yaml
+++ b/internal/api/openapi/rhtas-console.yaml
@@ -748,6 +748,19 @@ components:
         - type
         - status
         - content
+    CertificateStatus:
+      type: string
+      description: >
+        Status of the certificate, derived from trusted_root.json validFor window and X.509 validity.
+        active — in service, cert is valid.
+        expiring — in service, cert expires within 30 days.
+        expired — the X.509 cert has actually expired.
+        revoked — cert still valid but taken out of service.
+      enum:
+        - active
+        - expiring
+        - expired
+        - revoked
     CertificateInfo:
       type: object
       properties:
@@ -761,14 +774,19 @@ components:
           type: string
           description: Target type
         status:
-          type: string
-          description: Status of the target to which the certificate is associated.
+          $ref: "#/components/schemas/CertificateStatus"
         target:
           type: string
           description: The TUF target to which the certificate is associated.
-        expiration:
+        certExpiration:
           type: string
           description: Expiration date and time of the certificate (notAfter).
+        validForStart:
+          type: string
+          description: Start of the service window from trusted_root.json validFor (ISO 8601).
+        validForEnd:
+          type: string
+          description: End of the service window from trusted_root.json validFor (ISO 8601). Absent if still active.
         pem:
           type: string
           description: Certificate in PEM-encoded format.
@@ -778,7 +796,7 @@ components:
         - type
         - status
         - target
-        - expiration
+        - certExpiration
         - pem
     CertificateInfoList:
       type: object

--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -39,6 +39,14 @@ const (
 	CertificateRoleUnknown      CertificateRole = "unknown"
 )
 
+// Defines values for CertificateStatus.
+const (
+	Active   CertificateStatus = "active"
+	Expired  CertificateStatus = "expired"
+	Expiring CertificateStatus = "expiring"
+	Revoked  CertificateStatus = "revoked"
+)
+
 // Defines values for SystemHealthResponseRekorStatus.
 const (
 	SystemHealthResponseRekorStatusHealthy   SystemHealthResponseRekorStatus = "healthy"
@@ -186,8 +194,8 @@ type AttestationView struct {
 
 // CertificateInfo defines model for CertificateInfo.
 type CertificateInfo struct {
-	// Expiration Expiration date and time of the certificate (notAfter).
-	Expiration string `json:"expiration"`
+	// CertExpiration Expiration date and time of the certificate (notAfter).
+	CertExpiration string `json:"certExpiration"`
 
 	// Issuer Certificate issuer
 	Issuer string `json:"issuer"`
@@ -195,8 +203,8 @@ type CertificateInfo struct {
 	// Pem Certificate in PEM-encoded format.
 	Pem string `json:"pem"`
 
-	// Status Status of the target to which the certificate is associated.
-	Status string `json:"status"`
+	// Status Status of the certificate, derived from trusted_root.json validFor window and X.509 validity. active — in service, cert is valid. expiring — in service, cert expires within 30 days. expired — the X.509 cert has actually expired. revoked — cert still valid but taken out of service.
+	Status CertificateStatus `json:"status"`
 
 	// Subject Certificate subject
 	Subject string `json:"subject"`
@@ -206,6 +214,12 @@ type CertificateInfo struct {
 
 	// Type Target type
 	Type string `json:"type"`
+
+	// ValidForEnd End of the service window from trusted_root.json validFor (ISO 8601). Absent if still active.
+	ValidForEnd *string `json:"validForEnd,omitempty"`
+
+	// ValidForStart Start of the service window from trusted_root.json validFor (ISO 8601).
+	ValidForStart *string `json:"validForStart,omitempty"`
 }
 
 // CertificateInfoList defines model for CertificateInfoList.
@@ -215,6 +229,9 @@ type CertificateInfoList struct {
 
 // CertificateRole defines model for CertificateRole.
 type CertificateRole string
+
+// CertificateStatus Status of the certificate, derived from trusted_root.json validFor window and X.509 validity. active — in service, cert is valid. expiring — in service, cert expires within 30 days. expired — the X.509 cert has actually expired. revoked — cert still valid but taken out of service.
+type CertificateStatus string
 
 // Checkpoint defines model for Checkpoint.
 type Checkpoint struct {

--- a/internal/services/trust.go
+++ b/internal/services/trust.go
@@ -63,6 +63,7 @@ type trustService struct {
 	validForCache   map[string]validForWindow
 	validForExpiry  time.Time
 	validForRepoUrl string
+	validForFlight  singleflight.Group
 	tufRepoUrl      string
 	ctx             context.Context
 	cancel          context.CancelFunc
@@ -879,22 +880,26 @@ type validForWindow struct {
 
 func (s *trustService) getValidForLookup(ctx context.Context, tufRepoUrl string) map[string]validForWindow {
 	s.validForMu.RLock()
-	if s.validForCache != nil && s.validForRepoUrl == tufRepoUrl && time.Now().Before(s.validForExpiry) {
+	if s.validForCache != nil && urlsEqual(s.validForRepoUrl, tufRepoUrl) && time.Now().Before(s.validForExpiry) {
 		cached := s.validForCache
 		s.validForMu.RUnlock()
 		return cached
 	}
 	s.validForMu.RUnlock()
 
-	lookup := buildValidForLookup(ctx, s, tufRepoUrl)
+	v, _, _ := s.validForFlight.Do(tufRepoUrl, func() (interface{}, error) {
+		lookup := buildValidForLookup(ctx, s, tufRepoUrl)
 
-	s.validForMu.Lock()
-	s.validForCache = lookup
-	s.validForRepoUrl = tufRepoUrl
-	s.validForExpiry = time.Now().Add(s.refreshInterval)
-	s.validForMu.Unlock()
+		s.validForMu.Lock()
+		s.validForCache = lookup
+		s.validForRepoUrl = tufRepoUrl
+		s.validForExpiry = time.Now().Add(s.refreshInterval)
+		s.validForMu.Unlock()
 
-	return lookup
+		return lookup, nil
+	})
+
+	return v.(map[string]validForWindow)
 }
 
 func buildValidForLookup(ctx context.Context, s *trustService, tufRepoUrl string) map[string]validForWindow {

--- a/internal/services/trust.go
+++ b/internal/services/trust.go
@@ -2,7 +2,9 @@ package services
 
 import (
 	"context"
+	"crypto/sha256"
 	"crypto/x509"
+	"encoding/hex"
 	"encoding/json"
 	"encoding/pem"
 	"errors"
@@ -19,6 +21,7 @@ import (
 	"time"
 
 	"github.com/securesign/rhtas-console/internal/models"
+	"github.com/sigstore/sigstore-go/pkg/root"
 	"github.com/sigstore/sigstore-go/pkg/tuf"
 	"github.com/sigstore/sigstore-go/pkg/util"
 	"github.com/theupdateframework/go-tuf/data"
@@ -55,6 +58,10 @@ type trustService struct {
 	repo            *tufRepository
 	repoReady       bool
 	refreshInterval time.Duration
+
+	validForMu     sync.RWMutex
+	validForCache  map[string]validForWindow
+	validForExpiry time.Time
 	tufRepoUrl      string
 	ctx             context.Context
 	cancel          context.CancelFunc
@@ -235,6 +242,8 @@ func (s *trustService) GetCertificatesInfo(ctx context.Context, tufRepoUrl strin
 		return models.CertificateInfoList{}, http.StatusInternalServerError, fmt.Errorf("extracting target metadata: %w", err)
 	}
 
+	validForLookup := s.getValidForLookup(ctx, tufRepoUrl)
+
 	result := models.CertificateInfoList{}
 	var fetchErrors []string
 
@@ -258,7 +267,7 @@ func (s *trustService) GetCertificatesInfo(ctx context.Context, tufRepoUrl strin
 				continue
 			}
 
-			certInfoList, err := extractCertDetails(targetContent.Content)
+			parsedCerts, err := extractCertDetails(targetContent.Content)
 			if err != nil {
 				errMsg := fmt.Sprintf("failed to extract certificate details from target %s: %v", targetName, err)
 				log.Print(errMsg)
@@ -266,16 +275,36 @@ func (s *trustService) GetCertificatesInfo(ctx context.Context, tufRepoUrl strin
 				continue
 			}
 
-			for _, cert_info := range certInfoList.Data {
-				result.Data = append(result.Data, models.CertificateInfo{
-					Issuer:     cert_info.Issuer,
-					Subject:    cert_info.Subject,
-					Expiration: cert_info.Expiration,
-					Target:     targetName,
-					Status:     spec["status"], // Status from TUF metadata (Active, Expired, etc.)
-					Type:       targetType,
-					Pem:        cert_info.Pem,
-				})
+			now := time.Now()
+			for _, pc := range parsedCerts {
+				status := models.Active
+				if !pc.notAfter.IsZero() && now.After(pc.notAfter) {
+					status = models.Expired
+				} else if !pc.notAfter.IsZero() && pc.notAfter.Sub(now) <= 30*24*time.Hour {
+					status = models.Expiring
+				}
+
+				info := models.CertificateInfo{
+					Issuer:         pc.info.Issuer,
+					Subject:        pc.info.Subject,
+					CertExpiration: pc.info.CertExpiration,
+					Target:         targetName,
+					Status:         status,
+					Type:           targetType,
+					Pem:            pc.info.Pem,
+				}
+				if vf, ok := validForLookup[pc.fingerprint]; ok {
+					start := vf.start.Format(time.RFC3339)
+					info.ValidForStart = &start
+					if !vf.end.IsZero() {
+						end := vf.end.Format(time.RFC3339)
+						info.ValidForEnd = &end
+						if now.After(vf.end) && info.Status != models.Expired {
+							info.Status = models.Revoked
+						}
+					}
+				}
+				result.Data = append(result.Data, info)
 			}
 		}
 	}
@@ -791,9 +820,15 @@ func extractTargetMetadataInfo(targetsBytes []byte) (map[string]map[string]strin
 	return targetSpecs, nil
 }
 
+type parsedCertEntry struct {
+	info        models.CertificateInfo
+	fingerprint string
+	notAfter    time.Time
+}
+
 // extractCertDetails extracts subject, issuer & status from a PEM certificate
-func extractCertDetails(certPEM string) (models.CertificateInfoList, error) {
-	var results models.CertificateInfoList
+func extractCertDetails(certPEM string) ([]parsedCertEntry, error) {
+	var results []parsedCertEntry
 	rest := []byte(certPEM)
 	for {
 		block, remaining := pem.Decode(rest)
@@ -807,25 +842,106 @@ func extractCertDetails(certPEM string) (models.CertificateInfoList, error) {
 		}
 		cert, err := x509.ParseCertificate(block.Bytes)
 		if err != nil {
-			return models.CertificateInfoList{}, fmt.Errorf("failed to parse certificate: %w", err)
+			return nil, fmt.Errorf("failed to parse certificate: %w", err)
 		}
 		pemBytes := pem.EncodeToMemory(&pem.Block{
 			Type:  "CERTIFICATE",
 			Bytes: cert.Raw,
 		})
-		entry := models.CertificateInfo{
-			Subject:    cert.Subject.String(),
-			Issuer:     cert.Issuer.String(),
-			Expiration: cert.NotAfter.String(),
-			Pem:        string(pemBytes),
-		}
-		results.Data = append(results.Data, entry)
+		results = append(results, parsedCertEntry{
+			info: models.CertificateInfo{
+				Subject:        cert.Subject.String(),
+				Issuer:         cert.Issuer.String(),
+				CertExpiration: cert.NotAfter.String(),
+				Pem:            string(pemBytes),
+			},
+			fingerprint: certFingerprint(cert.Raw),
+			notAfter:    cert.NotAfter,
+		})
 	}
 
-	if len(results.Data) == 0 {
-		return models.CertificateInfoList{}, fmt.Errorf("no valid certificates found")
+	if len(results) == 0 {
+		return nil, fmt.Errorf("no valid certificates found")
 	}
 	return results, nil
+}
+
+func certFingerprint(raw []byte) string {
+	h := sha256.Sum256(raw)
+	return hex.EncodeToString(h[:])
+}
+
+type validForWindow struct {
+	start time.Time
+	end   time.Time
+}
+
+func (s *trustService) getValidForLookup(ctx context.Context, tufRepoUrl string) map[string]validForWindow {
+	s.validForMu.RLock()
+	if s.validForCache != nil && time.Now().Before(s.validForExpiry) {
+		cached := s.validForCache
+		s.validForMu.RUnlock()
+		return cached
+	}
+	s.validForMu.RUnlock()
+
+	lookup := buildValidForLookup(ctx, s, tufRepoUrl)
+
+	s.validForMu.Lock()
+	s.validForCache = lookup
+	s.validForExpiry = time.Now().Add(s.refreshInterval)
+	s.validForMu.Unlock()
+
+	return lookup
+}
+
+func buildValidForLookup(ctx context.Context, s *trustService, tufRepoUrl string) map[string]validForWindow {
+	lookup := make(map[string]validForWindow)
+
+	targetContent, statusCode, err := s.GetTargetFromTUFRepo(ctx, tufRepoUrl, "trusted_root.json")
+	if err != nil || statusCode != http.StatusOK {
+		log.Printf("failed to fetch trusted_root.json for validFor enrichment: %v", err)
+		return lookup
+	}
+
+	trustedRoot, err := root.NewTrustedRootFromJSON([]byte(targetContent.Content))
+	if err != nil {
+		log.Printf("failed to parse trusted_root.json for validFor enrichment: %v", err)
+		return lookup
+	}
+
+	for _, ca := range trustedRoot.FulcioCertificateAuthorities() {
+		fca, ok := ca.(*root.FulcioCertificateAuthority)
+		if !ok {
+			continue
+		}
+		w := validForWindow{start: fca.ValidityPeriodStart, end: fca.ValidityPeriodEnd}
+		if fca.Root != nil {
+			lookup[certFingerprint(fca.Root.Raw)] = w
+		}
+		for _, intermediate := range fca.Intermediates {
+			lookup[certFingerprint(intermediate.Raw)] = w
+		}
+	}
+
+	for _, tsa := range trustedRoot.TimestampingAuthorities() {
+		sta, ok := tsa.(*root.SigstoreTimestampingAuthority)
+		if !ok {
+			continue
+		}
+		w := validForWindow{start: sta.ValidityPeriodStart, end: sta.ValidityPeriodEnd}
+		if sta.Root != nil {
+			lookup[certFingerprint(sta.Root.Raw)] = w
+		}
+		if sta.Leaf != nil {
+			lookup[certFingerprint(sta.Leaf.Raw)] = w
+		}
+		for _, intermediate := range sta.Intermediates {
+			lookup[certFingerprint(intermediate.Raw)] = w
+		}
+	}
+
+	return lookup
 }
 
 // urlsEqual compares two URLs for logical equivalence, ignoring trailing slashes.

--- a/internal/services/trust.go
+++ b/internal/services/trust.go
@@ -59,9 +59,10 @@ type trustService struct {
 	repoReady       bool
 	refreshInterval time.Duration
 
-	validForMu     sync.RWMutex
-	validForCache  map[string]validForWindow
-	validForExpiry time.Time
+	validForMu      sync.RWMutex
+	validForCache   map[string]validForWindow
+	validForExpiry  time.Time
+	validForRepoUrl string
 	tufRepoUrl      string
 	ctx             context.Context
 	cancel          context.CancelFunc
@@ -852,7 +853,7 @@ func extractCertDetails(certPEM string) ([]parsedCertEntry, error) {
 			info: models.CertificateInfo{
 				Subject:        cert.Subject.String(),
 				Issuer:         cert.Issuer.String(),
-				CertExpiration: cert.NotAfter.String(),
+				CertExpiration: cert.NotAfter.UTC().Format(time.RFC3339),
 				Pem:            string(pemBytes),
 			},
 			fingerprint: certFingerprint(cert.Raw),
@@ -878,7 +879,7 @@ type validForWindow struct {
 
 func (s *trustService) getValidForLookup(ctx context.Context, tufRepoUrl string) map[string]validForWindow {
 	s.validForMu.RLock()
-	if s.validForCache != nil && time.Now().Before(s.validForExpiry) {
+	if s.validForCache != nil && s.validForRepoUrl == tufRepoUrl && time.Now().Before(s.validForExpiry) {
 		cached := s.validForCache
 		s.validForMu.RUnlock()
 		return cached
@@ -889,6 +890,7 @@ func (s *trustService) getValidForLookup(ctx context.Context, tufRepoUrl string)
 
 	s.validForMu.Lock()
 	s.validForCache = lookup
+	s.validForRepoUrl = tufRepoUrl
 	s.validForExpiry = time.Now().Add(s.refreshInterval)
 	s.validForMu.Unlock()
 
@@ -900,7 +902,7 @@ func buildValidForLookup(ctx context.Context, s *trustService, tufRepoUrl string
 
 	targetContent, statusCode, err := s.GetTargetFromTUFRepo(ctx, tufRepoUrl, "trusted_root.json")
 	if err != nil || statusCode != http.StatusOK {
-		log.Printf("failed to fetch trusted_root.json for validFor enrichment: %v", err)
+		log.Printf("failed to fetch trusted_root.json for validFor enrichment (statusCode=%d): %v", statusCode, err)
 		return lookup
 	}
 

--- a/internal/services/trust.go
+++ b/internal/services/trust.go
@@ -279,11 +279,9 @@ func (s *trustService) GetCertificatesInfo(ctx context.Context, tufRepoUrl strin
 
 			now := time.Now()
 			for _, pc := range parsedCerts {
-				status := models.Active
-				if !pc.notAfter.IsZero() && now.After(pc.notAfter) {
-					status = models.Expired
-				} else if !pc.notAfter.IsZero() && pc.notAfter.Sub(now) <= 30*24*time.Hour {
-					status = models.Expiring
+				var vfPtr *validForWindow
+				if vf, ok := validForLookup[pc.fingerprint]; ok {
+					vfPtr = &vf
 				}
 
 				info := models.CertificateInfo{
@@ -291,19 +289,16 @@ func (s *trustService) GetCertificatesInfo(ctx context.Context, tufRepoUrl strin
 					Subject:        pc.info.Subject,
 					CertExpiration: pc.info.CertExpiration,
 					Target:         targetName,
-					Status:         status,
+					Status:         computeCertStatus(pc.notAfter, vfPtr, now),
 					Type:           targetType,
 					Pem:            pc.info.Pem,
 				}
-				if vf, ok := validForLookup[pc.fingerprint]; ok {
-					start := vf.start.Format(time.RFC3339)
+				if vfPtr != nil {
+					start := vfPtr.start.Format(time.RFC3339)
 					info.ValidForStart = &start
-					if !vf.end.IsZero() {
-						end := vf.end.Format(time.RFC3339)
+					if !vfPtr.end.IsZero() {
+						end := vfPtr.end.Format(time.RFC3339)
 						info.ValidForEnd = &end
-						if now.After(vf.end) && info.Status != models.Expired {
-							info.Status = models.Revoked
-						}
 					}
 				}
 				result.Data = append(result.Data, info)
@@ -876,6 +871,20 @@ func certFingerprint(raw []byte) string {
 type validForWindow struct {
 	start time.Time
 	end   time.Time
+}
+
+func computeCertStatus(notAfter time.Time, validFor *validForWindow, now time.Time) models.CertificateStatus {
+	expired := !notAfter.IsZero() && now.After(notAfter)
+	if expired {
+		return models.Expired
+	}
+	if validFor != nil && !validFor.end.IsZero() && now.After(validFor.end) {
+		return models.Revoked
+	}
+	if !notAfter.IsZero() && notAfter.Sub(now) <= 30*24*time.Hour {
+		return models.Expiring
+	}
+	return models.Active
 }
 
 func (s *trustService) getValidForLookup(ctx context.Context, tufRepoUrl string) map[string]validForWindow {

--- a/internal/services/trust.go
+++ b/internal/services/trust.go
@@ -888,13 +888,15 @@ func (s *trustService) getValidForLookup(ctx context.Context, tufRepoUrl string)
 	s.validForMu.RUnlock()
 
 	v, _, _ := s.validForFlight.Do(tufRepoUrl, func() (interface{}, error) {
-		lookup := buildValidForLookup(ctx, s, tufRepoUrl)
+		lookup := buildValidForLookup(context.Background(), s, tufRepoUrl)
 
-		s.validForMu.Lock()
-		s.validForCache = lookup
-		s.validForRepoUrl = tufRepoUrl
-		s.validForExpiry = time.Now().Add(s.refreshInterval)
-		s.validForMu.Unlock()
+		if len(lookup) > 0 {
+			s.validForMu.Lock()
+			s.validForCache = lookup
+			s.validForRepoUrl = tufRepoUrl
+			s.validForExpiry = time.Now().Add(s.refreshInterval)
+			s.validForMu.Unlock()
+		}
 
 		return lookup, nil
 	})

--- a/internal/services/trust_test.go
+++ b/internal/services/trust_test.go
@@ -1,6 +1,7 @@
 package services
 
 import (
+	"context"
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/rand"
@@ -216,7 +217,7 @@ func TestGetValidForLookupCaching(t *testing.T) {
 		s.validForRepoUrl = "https://tuf.example.com"
 		s.validForExpiry = time.Now().Add(5 * time.Minute)
 
-		got := s.getValidForLookup(nil, "https://tuf.example.com")
+		got := s.getValidForLookup(context.TODO(), "https://tuf.example.com")
 		if len(got) != 1 {
 			t.Errorf("expected cached map with 1 entry, got %d", len(got))
 		}
@@ -236,7 +237,7 @@ func TestGetValidForLookupCaching(t *testing.T) {
 		s.validForRepoUrl = "https://tuf.example.com"
 		s.validForExpiry = time.Now().Add(5 * time.Minute)
 
-		got := s.getValidForLookup(nil, "https://other.example.com")
+		got := s.getValidForLookup(context.TODO(), "https://other.example.com")
 		if _, ok := got["abc123"]; ok {
 			t.Error("should not return cached result for different URL")
 		}
@@ -253,7 +254,7 @@ func TestGetValidForLookupCaching(t *testing.T) {
 		s.validForRepoUrl = "https://tuf.example.com"
 		s.validForExpiry = time.Now().Add(-1 * time.Minute)
 
-		got := s.getValidForLookup(nil, "https://tuf.example.com")
+		got := s.getValidForLookup(context.TODO(), "https://tuf.example.com")
 		if _, ok := got["abc123"]; ok {
 			t.Error("should not return expired cached result")
 		}
@@ -270,7 +271,7 @@ func TestGetValidForLookupCaching(t *testing.T) {
 		s.validForRepoUrl = "https://tuf.example.com/"
 		s.validForExpiry = time.Now().Add(5 * time.Minute)
 
-		got := s.getValidForLookup(nil, "https://tuf.example.com")
+		got := s.getValidForLookup(context.TODO(), "https://tuf.example.com")
 		if len(got) != 1 {
 			t.Errorf("expected cached map with 1 entry for equivalent URL, got %d", len(got))
 		}

--- a/internal/services/trust_test.go
+++ b/internal/services/trust_test.go
@@ -1,0 +1,278 @@
+package services
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/sha256"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/hex"
+	"encoding/pem"
+	"math/big"
+	"testing"
+	"time"
+
+	"github.com/securesign/rhtas-console/internal/models"
+)
+
+func generateTestCert(t *testing.T, notBefore, notAfter time.Time, subject string) (string, []byte) {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("failed to generate key: %v", err)
+	}
+	tmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: subject},
+		Issuer:       pkix.Name{CommonName: subject},
+		NotBefore:    notBefore,
+		NotAfter:     notAfter,
+		KeyUsage:     x509.KeyUsageCertSign,
+		IsCA:         true,
+	}
+	certDER, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	if err != nil {
+		t.Fatalf("failed to create certificate: %v", err)
+	}
+	pemBytes := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: certDER})
+	return string(pemBytes), certDER
+}
+
+func TestCertFingerprint(t *testing.T) {
+	input := []byte("test data for fingerprint")
+	got := certFingerprint(input)
+	h := sha256.Sum256(input)
+	want := hex.EncodeToString(h[:])
+	if got != want {
+		t.Errorf("certFingerprint() = %q, want %q", got, want)
+	}
+}
+
+func TestExtractCertDetails(t *testing.T) {
+	now := time.Now()
+	notBefore := now.Add(-1 * time.Hour)
+	notAfter := now.Add(365 * 24 * time.Hour)
+
+	t.Run("valid single cert", func(t *testing.T) {
+		pemStr, certDER := generateTestCert(t, notBefore, notAfter, "test-subject")
+		results, err := extractCertDetails(pemStr)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(results) != 1 {
+			t.Fatalf("expected 1 result, got %d", len(results))
+		}
+		entry := results[0]
+		if entry.info.Subject != "CN=test-subject" {
+			t.Errorf("subject = %q, want %q", entry.info.Subject, "CN=test-subject")
+		}
+		if entry.info.Issuer != "CN=test-subject" {
+			t.Errorf("issuer = %q, want %q", entry.info.Issuer, "CN=test-subject")
+		}
+		if _, err := time.Parse(time.RFC3339, entry.info.CertExpiration); err != nil {
+			t.Errorf("certExpiration %q is not RFC3339: %v", entry.info.CertExpiration, err)
+		}
+		h := sha256.Sum256(certDER)
+		wantFP := hex.EncodeToString(h[:])
+		if entry.fingerprint != wantFP {
+			t.Errorf("fingerprint = %q, want %q", entry.fingerprint, wantFP)
+		}
+		if entry.notAfter.IsZero() {
+			t.Error("notAfter should not be zero")
+		}
+	})
+
+	t.Run("multi cert PEM", func(t *testing.T) {
+		pem1, _ := generateTestCert(t, notBefore, notAfter, "cert-one")
+		pem2, _ := generateTestCert(t, notBefore, notAfter, "cert-two")
+		combined := pem1 + pem2
+		results, err := extractCertDetails(combined)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(results) != 2 {
+			t.Fatalf("expected 2 results, got %d", len(results))
+		}
+		if results[0].info.Subject != "CN=cert-one" {
+			t.Errorf("first subject = %q, want %q", results[0].info.Subject, "CN=cert-one")
+		}
+		if results[1].info.Subject != "CN=cert-two" {
+			t.Errorf("second subject = %q, want %q", results[1].info.Subject, "CN=cert-two")
+		}
+	})
+
+	t.Run("invalid PEM", func(t *testing.T) {
+		_, err := extractCertDetails("not a valid PEM")
+		if err == nil {
+			t.Error("expected error for invalid PEM")
+		}
+	})
+
+	t.Run("non-certificate PEM block", func(t *testing.T) {
+		rsaBlock := pem.EncodeToMemory(&pem.Block{Type: "RSA PRIVATE KEY", Bytes: []byte("fake")})
+		_, err := extractCertDetails(string(rsaBlock))
+		if err == nil {
+			t.Error("expected error for non-certificate PEM block")
+		}
+	})
+}
+
+func TestComputeCertStatus(t *testing.T) {
+	now := time.Date(2026, 7, 23, 12, 0, 0, 0, time.UTC)
+
+	tests := []struct {
+		name     string
+		notAfter time.Time
+		validFor *validForWindow
+		want     models.CertificateStatus
+	}{
+		{
+			name:     "active, no validFor",
+			notAfter: now.Add(365 * 24 * time.Hour),
+			want:     models.Active,
+		},
+		{
+			name:     "expiring in 29 days",
+			notAfter: now.Add(29 * 24 * time.Hour),
+			want:     models.Expiring,
+		},
+		{
+			name:     "expiring at exactly 30 days boundary",
+			notAfter: now.Add(30 * 24 * time.Hour),
+			want:     models.Expiring,
+		},
+		{
+			name:     "active at 31 days",
+			notAfter: now.Add(31 * 24 * time.Hour),
+			want:     models.Active,
+		},
+		{
+			name:     "expired cert",
+			notAfter: now.Add(-1 * time.Hour),
+			want:     models.Expired,
+		},
+		{
+			name:     "revoked: validFor.end passed, cert still valid",
+			notAfter: now.Add(365 * 24 * time.Hour),
+			validFor: &validForWindow{
+				start: now.Add(-2 * 365 * 24 * time.Hour),
+				end:   now.Add(-30 * 24 * time.Hour),
+			},
+			want: models.Revoked,
+		},
+		{
+			name:     "expired takes precedence over revoked",
+			notAfter: now.Add(-1 * time.Hour),
+			validFor: &validForWindow{
+				start: now.Add(-2 * 365 * 24 * time.Hour),
+				end:   now.Add(-30 * 24 * time.Hour),
+			},
+			want: models.Expired,
+		},
+		{
+			name:     "validFor.end in future, cert valid",
+			notAfter: now.Add(365 * 24 * time.Hour),
+			validFor: &validForWindow{
+				start: now.Add(-30 * 24 * time.Hour),
+				end:   now.Add(365 * 24 * time.Hour),
+			},
+			want: models.Active,
+		},
+		{
+			name:     "validFor.end in future, cert expiring",
+			notAfter: now.Add(15 * 24 * time.Hour),
+			validFor: &validForWindow{
+				start: now.Add(-30 * 24 * time.Hour),
+				end:   now.Add(365 * 24 * time.Hour),
+			},
+			want: models.Expiring,
+		},
+		{
+			name: "zero notAfter defaults to active",
+			want: models.Active,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := computeCertStatus(tt.notAfter, tt.validFor, now)
+			if got != tt.want {
+				t.Errorf("computeCertStatus() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGetValidForLookupCaching(t *testing.T) {
+	t.Run("cache hit with matching URL", func(t *testing.T) {
+		s := &trustService{
+			refreshInterval: 5 * time.Minute,
+		}
+		cached := map[string]validForWindow{
+			"abc123": {start: time.Now(), end: time.Time{}},
+		}
+		s.validForCache = cached
+		s.validForRepoUrl = "https://tuf.example.com"
+		s.validForExpiry = time.Now().Add(5 * time.Minute)
+
+		got := s.getValidForLookup(nil, "https://tuf.example.com")
+		if len(got) != 1 {
+			t.Errorf("expected cached map with 1 entry, got %d", len(got))
+		}
+		if _, ok := got["abc123"]; !ok {
+			t.Error("expected key 'abc123' in cached result")
+		}
+	})
+
+	t.Run("cache miss on different URL", func(t *testing.T) {
+		s := &trustService{
+			refreshInterval: 5 * time.Minute,
+		}
+		cached := map[string]validForWindow{
+			"abc123": {start: time.Now(), end: time.Time{}},
+		}
+		s.validForCache = cached
+		s.validForRepoUrl = "https://tuf.example.com"
+		s.validForExpiry = time.Now().Add(5 * time.Minute)
+
+		got := s.getValidForLookup(nil, "https://other.example.com")
+		if _, ok := got["abc123"]; ok {
+			t.Error("should not return cached result for different URL")
+		}
+	})
+
+	t.Run("cache miss on expired TTL", func(t *testing.T) {
+		s := &trustService{
+			refreshInterval: 5 * time.Minute,
+		}
+		cached := map[string]validForWindow{
+			"abc123": {start: time.Now(), end: time.Time{}},
+		}
+		s.validForCache = cached
+		s.validForRepoUrl = "https://tuf.example.com"
+		s.validForExpiry = time.Now().Add(-1 * time.Minute)
+
+		got := s.getValidForLookup(nil, "https://tuf.example.com")
+		if _, ok := got["abc123"]; ok {
+			t.Error("should not return expired cached result")
+		}
+	})
+
+	t.Run("cache hit with trailing slash URL equivalence", func(t *testing.T) {
+		s := &trustService{
+			refreshInterval: 5 * time.Minute,
+		}
+		cached := map[string]validForWindow{
+			"abc123": {start: time.Now(), end: time.Time{}},
+		}
+		s.validForCache = cached
+		s.validForRepoUrl = "https://tuf.example.com/"
+		s.validForExpiry = time.Now().Add(5 * time.Minute)
+
+		got := s.getValidForLookup(nil, "https://tuf.example.com")
+		if len(got) != 1 {
+			t.Errorf("expected cached map with 1 entry for equivalent URL, got %d", len(got))
+		}
+	})
+}


### PR DESCRIPTION
Assisted by: Claude Code.

### PR description:
- Enrich the certificates API with validForStart/validForEnd service windows from trusted_root.json, correlated by certificate fingerprint
- Rename expiration -> certExpiration to disambiguate X.509 cert expiry from service window
- Compute certificate status from cert validity and service window instead of TUF target metadata:
  - active: in service, cert is valid
  - expiring: in service, cert expires within 30 days
  - expired: the X.509 cert has actually expired
  - revoked: cert still valid but taken out of service
- Cache the validFor lookup with TTL, singleflight deduplication, and URL-aware invalidation
- Format certExpiration as RFC 3339 (consistent with validForStart/validForEnd)
- Add unit tests for status computation, cert parsing, fingerprinting, and cache behavior