### PR TITLE
feat: extend metadata-info endpoint to return all 4 TUF roles

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ The backend exposes the following RESTful endpoints, as defined in the OpenAPI s
 | GET    | `/api/v1/rekor/entries/{uuid}`              | Retrieves a Rekor transparency log entry by UUID. |
 | GET    | `/api/v1/rekor/public-key`                  | Retrieves the Rekor public key in PEM format.     |
 | GET    | `/api/v1/trust/config`                      | Retrieves Fulcio certificate authorities and Rekor transparency logs. |
-| GET    | `/api/v1/trust/root-metadata-info`          | Retrieves the full history of TUF root metadata versions, including version, expiration date, and status (valid, expiring, expired). |
+| GET    | `/api/v1/trust/metadata-info`               | Retrieves metadata info for all TUF roles (root, targets, snapshot, timestamp), including version, expiration date, and status (valid, expiring, expired). |
 | GET    | `/api/v1/trust/targets`                     | Retrieves all TUF targets. |
 | GET    | `/api/v1/trust/target`                      | Retrieves a specific TUF target. |
 | GET    | `/api/v1/trust/targets/certificates`        | Retrieves certificates for TUF targets. |

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -104,9 +104,9 @@ func (h *Handler) GetApiV1TrustConfig(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, statusCode, resp)
 }
 
-func (h *Handler) GetApiV1TrustRootMetadata(w http.ResponseWriter, r *http.Request) {
+func (h *Handler) GetApiV1TrustMetadataInfo(w http.ResponseWriter, r *http.Request) {
 	tufRepoUrl := h.trustService.GetTUFRepoURL()
-	resp, statusCode, err := h.trustService.GetTrustRootMetadataInfo(r.Context(), tufRepoUrl)
+	resp, statusCode, err := h.trustService.GetTrustMetadataInfo(r.Context(), tufRepoUrl)
 	if err != nil {
 		writeError(w, statusCode, err.Error())
 		return

--- a/internal/api/openapi/rhtas-console.yaml
+++ b/internal/api/openapi/rhtas-console.yaml
@@ -221,12 +221,13 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Error"
-  /api/v1/trust/root-metadata-info:
+  /api/v1/trust/metadata-info:
     get:
-      summary: Get TUF Root Metadata
+      summary: Get TUF Metadata Info
       description: |
-        Retrieves metadata information about the TUF root versions from the trust repository.
-        This includes metadata versioning, expiration timestamps, and current status (e.g., valid or expired).
+        Retrieves metadata information for all TUF roles (root, targets, snapshot, timestamp)
+        from the trust repository. Each role includes versioning, expiration timestamps,
+        and current status (e.g., valid, expiring, or expired).
       tags:
         - Trust
       parameters:
@@ -239,11 +240,11 @@ paths:
             example: https://tuf-repo-cdn.sigstore.dev/
       responses:
         "200":
-          description: List of TUF root metadata entries
+          description: TUF metadata info grouped by role
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/RootMetadataInfoList"
+                $ref: "#/components/schemas/MetadataInfoResponse"
         "400":
           description: Invalid input
           content:
@@ -684,32 +685,35 @@ components:
         - registry
         - metadata
         - digest
-    RootMetadataInfo:
+    MetadataInfo:
       type: object
       properties:
         version:
           type: string
-          description: Version of the TUF root metadata
+          description: Version of the TUF metadata
         expires:
           type: string
-          description: Expiry date of the TUF root metadata
+          description: Expiry date of the TUF metadata
         status:
           type: string
-          description: Status of the TUF root metadata
+          description: Status of the TUF metadata (valid, expiring, expired)
       required:
         - version
         - expires
         - status
-    RootMetadataInfoList:
+    MetadataInfoResponse:
       type: object
       properties:
         repo-url:
           type: string
           description: URL of the TUF repository
         data:
-          type: array
-          items:
-            $ref: "#/components/schemas/RootMetadataInfo"
+          type: object
+          description: Metadata info grouped by TUF role (root, targets, snapshot, timestamp)
+          additionalProperties:
+            type: array
+            items:
+              $ref: "#/components/schemas/MetadataInfo"
       required:
         - data
     TargetsList:

--- a/internal/api/routes.go
+++ b/internal/api/routes.go
@@ -15,7 +15,7 @@ func RegisterRoutes(r *chi.Mux, as services.ArtifactService, rs services.RekorSe
 	r.Get("/api/v1/rekor/entries/{uuid}", handler.GetApiV1RekorEntriesUuid)
 	r.Get("/api/v1/rekor/public-key", handler.GetApiV1RekorPublicKey)
 	r.Get("/api/v1/trust/config", handler.GetApiV1TrustConfig)
-	r.Get("/api/v1/trust/root-metadata-info", handler.GetApiV1TrustRootMetadata)
+	r.Get("/api/v1/trust/metadata-info", handler.GetApiV1TrustMetadataInfo)
 	r.Get("/api/v1/trust/targets", handler.GetApiV1TrustTargets)
 	r.Get("/api/v1/trust/target", handler.GetApiV1TrustTarget)
 	r.Get("/api/v1/trust/targets/certificates", handler.GetApiV1TrustTargetsCertificates)

--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -307,6 +307,27 @@ type Metadata struct {
 	Size int64 `json:"size"`
 }
 
+// MetadataInfo defines model for MetadataInfo.
+type MetadataInfo struct {
+	// Expires Expiry date of the TUF metadata
+	Expires string `json:"expires"`
+
+	// Status Status of the TUF metadata (valid, expiring, expired)
+	Status string `json:"status"`
+
+	// Version Version of the TUF metadata
+	Version string `json:"version"`
+}
+
+// MetadataInfoResponse defines model for MetadataInfoResponse.
+type MetadataInfoResponse struct {
+	// Data Metadata info grouped by TUF role (root, targets, snapshot, timestamp)
+	Data map[string][]MetadataInfo `json:"data"`
+
+	// RepoUrl URL of the TUF repository
+	RepoUrl *string `json:"repo-url,omitempty"`
+}
+
 // ParsedCertificate defines model for ParsedCertificate.
 type ParsedCertificate struct {
 	IsCa   bool   `json:"isCa"`
@@ -328,26 +349,6 @@ type ParsedCertificate struct {
 type RekorPublicKey struct {
 	// PublicKey Rekor public key in PEM format
 	PublicKey string `json:"publicKey"`
-}
-
-// RootMetadataInfo defines model for RootMetadataInfo.
-type RootMetadataInfo struct {
-	// Expires Expiry date of the TUF root metadata
-	Expires string `json:"expires"`
-
-	// Status Status of the TUF root metadata
-	Status string `json:"status"`
-
-	// Version Version of the TUF root metadata
-	Version string `json:"version"`
-}
-
-// RootMetadataInfoList defines model for RootMetadataInfoList.
-type RootMetadataInfoList struct {
-	Data []RootMetadataInfo `json:"data"`
-
-	// RepoUrl URL of the TUF repository
-	RepoUrl *string `json:"repo-url,omitempty"`
 }
 
 // SignatureView defines model for SignatureView.
@@ -566,8 +567,8 @@ type GetApiV1TrustConfigParams struct {
 	TufRepositoryUrl *string `form:"tufRepositoryUrl,omitempty" json:"tufRepositoryUrl,omitempty"`
 }
 
-// GetApiV1TrustRootMetadataInfoParams defines parameters for GetApiV1TrustRootMetadataInfo.
-type GetApiV1TrustRootMetadataInfoParams struct {
+// GetApiV1TrustMetadataInfoParams defines parameters for GetApiV1TrustMetadataInfo.
+type GetApiV1TrustMetadataInfoParams struct {
 	TufRepositoryUrl *string `form:"tufRepositoryUrl,omitempty" json:"tufRepositoryUrl,omitempty"`
 }
 
@@ -616,9 +617,9 @@ type ServerInterface interface {
 	// Get Trust Coverage
 	// (GET /api/v1/trust/coverage)
 	GetApiV1TrustCoverage(w http.ResponseWriter, r *http.Request)
-	// Get TUF Root Metadata
-	// (GET /api/v1/trust/root-metadata-info)
-	GetApiV1TrustRootMetadataInfo(w http.ResponseWriter, r *http.Request, params GetApiV1TrustRootMetadataInfoParams)
+	// Get TUF Metadata Info
+	// (GET /api/v1/trust/metadata-info)
+	GetApiV1TrustMetadataInfo(w http.ResponseWriter, r *http.Request, params GetApiV1TrustMetadataInfoParams)
 	// Get TUF Target File Content
 	// (GET /api/v1/trust/target)
 	GetApiV1TrustTarget(w http.ResponseWriter, r *http.Request, params GetApiV1TrustTargetParams)
@@ -685,9 +686,9 @@ func (_ Unimplemented) GetApiV1TrustCoverage(w http.ResponseWriter, r *http.Requ
 	w.WriteHeader(http.StatusNotImplemented)
 }
 
-// Get TUF Root Metadata
-// (GET /api/v1/trust/root-metadata-info)
-func (_ Unimplemented) GetApiV1TrustRootMetadataInfo(w http.ResponseWriter, r *http.Request, params GetApiV1TrustRootMetadataInfoParams) {
+// Get TUF Metadata Info
+// (GET /api/v1/trust/metadata-info)
+func (_ Unimplemented) GetApiV1TrustMetadataInfo(w http.ResponseWriter, r *http.Request, params GetApiV1TrustMetadataInfoParams) {
 	w.WriteHeader(http.StatusNotImplemented)
 }
 
@@ -896,13 +897,13 @@ func (siw *ServerInterfaceWrapper) GetApiV1TrustCoverage(w http.ResponseWriter, 
 	handler.ServeHTTP(w, r)
 }
 
-// GetApiV1TrustRootMetadataInfo operation middleware
-func (siw *ServerInterfaceWrapper) GetApiV1TrustRootMetadataInfo(w http.ResponseWriter, r *http.Request) {
+// GetApiV1TrustMetadataInfo operation middleware
+func (siw *ServerInterfaceWrapper) GetApiV1TrustMetadataInfo(w http.ResponseWriter, r *http.Request) {
 
 	var err error
 
 	// Parameter object where we will unmarshal all parameters from the context
-	var params GetApiV1TrustRootMetadataInfoParams
+	var params GetApiV1TrustMetadataInfoParams
 
 	// ------------- Optional query parameter "tufRepositoryUrl" -------------
 
@@ -913,7 +914,7 @@ func (siw *ServerInterfaceWrapper) GetApiV1TrustRootMetadataInfo(w http.Response
 	}
 
 	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		siw.Handler.GetApiV1TrustRootMetadataInfo(w, r, params)
+		siw.Handler.GetApiV1TrustMetadataInfo(w, r, params)
 	}))
 
 	for _, middleware := range siw.HandlerMiddlewares {
@@ -1171,7 +1172,7 @@ func HandlerWithOptions(si ServerInterface, options ChiServerOptions) http.Handl
 		r.Get(options.BaseURL+"/api/v1/trust/coverage", wrapper.GetApiV1TrustCoverage)
 	})
 	r.Group(func(r chi.Router) {
-		r.Get(options.BaseURL+"/api/v1/trust/root-metadata-info", wrapper.GetApiV1TrustRootMetadataInfo)
+		r.Get(options.BaseURL+"/api/v1/trust/metadata-info", wrapper.GetApiV1TrustMetadataInfo)
 	})
 	r.Group(func(r chi.Router) {
 		r.Get(options.BaseURL+"/api/v1/trust/target", wrapper.GetApiV1TrustTarget)

--- a/internal/services/trust.go
+++ b/internal/services/trust.go
@@ -43,7 +43,7 @@ type TrustServiceFlags struct {
 
 type TrustService interface {
 	GetTrustConfig(ctx context.Context, tufRepoUrl string) (cfg models.TrustConfig, statusCode int, err error)
-	GetTrustRootMetadataInfo(ctx context.Context, tufRepoUrl string) (info models.RootMetadataInfoList, statusCode int, err error)
+	GetTrustMetadataInfo(ctx context.Context, tufRepoUrl string) (info models.MetadataInfoResponse, statusCode int, err error)
 	GetTarget(ctx context.Context, tufRepoUrl string, target string) (content models.TargetContent, statusCode int, err error)
 	GetCertificatesInfo(ctx context.Context, tufRepoUrl string) (certs models.CertificateInfoList, statusCode int, err error)
 	GetAllTargets(ctx context.Context, tufRepoUrl string) (targets models.TargetsList, statusCode int, err error)
@@ -153,37 +153,36 @@ func (s *trustService) GetTrustConfig(ctx context.Context, tufRepoUrl string) (m
 	}, http.StatusOK, nil
 }
 
-func (s *trustService) GetTrustRootMetadataInfo(ctx context.Context, tufRepoUrl string) (models.RootMetadataInfoList, int, error) {
+func (s *trustService) GetTrustMetadataInfo(ctx context.Context, tufRepoUrl string) (models.MetadataInfoResponse, int, error) {
 	repo, statusCode, err := s.getOrCreateUpdater(ctx, tufRepoUrl)
 	if err != nil {
-		return models.RootMetadataInfoList{}, statusCode, err
+		return models.MetadataInfoResponse{}, statusCode, err
 	}
 
 	repo.lock.RLock()
 	defer repo.lock.RUnlock()
 
-	// Fetch all root metadata versions
-	latestRootMeta := repo.updater.GetTrustedMetadataSet().Root
-	if latestRootMeta == nil {
-		return models.RootMetadataInfoList{}, http.StatusServiceUnavailable, fmt.Errorf("latest root metadata not available")
+	trustedMeta := repo.updater.GetTrustedMetadataSet()
+
+	// Root: fetch all historical versions
+	if trustedMeta.Root == nil {
+		return models.MetadataInfoResponse{}, http.StatusServiceUnavailable, fmt.Errorf("root metadata not available")
 	}
 
-	latestVersion := latestRootMeta.Signed.Version
+	latestVersion := trustedMeta.Root.Signed.Version
 	var allRootBytes [][]byte
-	latestRootBytes, err := latestRootMeta.ToBytes(true)
+	latestRootBytes, err := trustedMeta.Root.ToBytes(true)
 	if err != nil {
-		return models.RootMetadataInfoList{}, http.StatusInternalServerError, fmt.Errorf("failed to get signed latest root bytes: %w", err)
+		return models.MetadataInfoResponse{}, http.StatusInternalServerError, fmt.Errorf("failed to get signed latest root bytes: %w", err)
 	}
 	allRootBytes = append(allRootBytes, latestRootBytes)
 
-	// Fetch previous versions
 	for version := 1; version < int(latestVersion); version++ {
 		rootFilename := fmt.Sprintf("%d.root.json", version)
 		metadataURL, err := url.JoinPath(repo.remoteMetadataURL, rootFilename)
 		if err != nil {
 			continue
 		}
-
 		rootBytes, err := fetchRootJSON(ctx, metadataURL)
 		if err != nil {
 			continue
@@ -195,17 +194,39 @@ func (s *trustService) GetTrustRootMetadataInfo(ctx context.Context, tufRepoUrl 
 		allRootBytes = append(allRootBytes, rootBytes)
 	}
 
-	var results models.RootMetadataInfoList
+	var rootEntries []models.MetadataInfo
 	for _, rootBytes := range allRootBytes {
 		rootInfo, err := extractRootMetadataInfo(rootBytes)
 		if err != nil {
-			return models.RootMetadataInfoList{}, http.StatusInternalServerError, fmt.Errorf("extracting root metadata info: %w", err)
+			return models.MetadataInfoResponse{}, http.StatusInternalServerError, fmt.Errorf("extracting root metadata info: %w", err)
 		}
-		results.Data = append(results.Data, rootInfo)
+		rootEntries = append(rootEntries, rootInfo)
 	}
 
-	results.RepoUrl = &repo.opts.RepositoryBaseURL
-	return results, http.StatusOK, nil
+	result := models.MetadataInfoResponse{
+		Data:    map[string][]models.MetadataInfo{"root": rootEntries},
+		RepoUrl: &repo.opts.RepositoryBaseURL,
+	}
+
+	if targets := trustedMeta.Targets["targets"]; targets != nil {
+		result.Data["targets"] = []models.MetadataInfo{
+			metadataInfoFromVersionAndExpires(targets.Signed.Version, targets.Signed.Expires),
+		}
+	}
+
+	if trustedMeta.Snapshot != nil {
+		result.Data["snapshot"] = []models.MetadataInfo{
+			metadataInfoFromVersionAndExpires(trustedMeta.Snapshot.Signed.Version, trustedMeta.Snapshot.Signed.Expires),
+		}
+	}
+
+	if trustedMeta.Timestamp != nil {
+		result.Data["timestamp"] = []models.MetadataInfo{
+			metadataInfoFromVersionAndExpires(trustedMeta.Timestamp.Signed.Version, trustedMeta.Timestamp.Signed.Expires),
+		}
+	}
+
+	return result, http.StatusOK, nil
 }
 
 func (s *trustService) GetTarget(ctx context.Context, tufRepoUrl string, target string) (models.TargetContent, int, error) {
@@ -748,8 +769,25 @@ func buildTufConfig(opts *tuf.Options) (*config.UpdaterConfig, error) {
 	return tufCfg, nil
 }
 
-// extractRootMetadataInfo retrieves TUF root metadata info including version, expiration, and status.
-func extractRootMetadataInfo(rootMetadataBytes []byte) (models.RootMetadataInfo, error) {
+func metadataInfoFromVersionAndExpires(version int64, expires time.Time) models.MetadataInfo {
+	now := time.Now().UTC()
+	var status string
+	switch {
+	case expires.Before(now):
+		status = "expired"
+	case expires.Sub(now) < 30*24*time.Hour:
+		status = "expiring"
+	default:
+		status = "valid"
+	}
+	return models.MetadataInfo{
+		Version: strconv.FormatInt(version, 10),
+		Expires: expires.Format(time.RFC3339),
+		Status:  status,
+	}
+}
+
+func extractRootMetadataInfo(rootMetadataBytes []byte) (models.MetadataInfo, error) {
 	var parsed struct {
 		Signed struct {
 			Expired string `json:"expires"`
@@ -758,12 +796,12 @@ func extractRootMetadataInfo(rootMetadataBytes []byte) (models.RootMetadataInfo,
 	}
 
 	if err := json.Unmarshal(rootMetadataBytes, &parsed); err != nil {
-		return models.RootMetadataInfo{}, fmt.Errorf("unmarshal root metadata: %w", err)
+		return models.MetadataInfo{}, fmt.Errorf("unmarshal root metadata: %w", err)
 	}
 
 	expiresTime, err := time.Parse(time.RFC3339, parsed.Signed.Expired)
 	if err != nil {
-		return models.RootMetadataInfo{}, fmt.Errorf("parse expires time: %w", err)
+		return models.MetadataInfo{}, fmt.Errorf("parse expires time: %w", err)
 	}
 
 	now := time.Now().UTC()
@@ -778,13 +816,11 @@ func extractRootMetadataInfo(rootMetadataBytes []byte) (models.RootMetadataInfo,
 		status = "valid"
 	}
 
-	rootMetadataInfo := models.RootMetadataInfo{
+	return models.MetadataInfo{
 		Version: strconv.Itoa(parsed.Signed.Version),
 		Expires: parsed.Signed.Expired,
 		Status:  status,
-	}
-
-	return rootMetadataInfo, nil
+	}, nil
 }
 
 // extractTargetMetadataInfo extracts status & usage of targets

--- a/internal/services/trust.go
+++ b/internal/services/trust.go
@@ -809,23 +809,7 @@ func extractRootMetadataInfo(rootMetadataBytes []byte) (models.MetadataInfo, err
 		return models.MetadataInfo{}, fmt.Errorf("parse expires time: %w", err)
 	}
 
-	now := time.Now().UTC()
-	var status string
-
-	switch {
-	case expiresTime.Before(now):
-		status = "expired"
-	case expiresTime.Sub(now) <= 30*24*time.Hour:
-		status = "expiring"
-	default:
-		status = "valid"
-	}
-
-	return models.MetadataInfo{
-		Version: strconv.Itoa(parsed.Signed.Version),
-		Expires: parsed.Signed.Expired,
-		Status:  status,
-	}, nil
+	return metadataInfoFromVersionAndExpires(int64(parsed.Signed.Version), expiresTime), nil
 }
 
 // extractTargetMetadataInfo extracts status & usage of targets

--- a/internal/services/trust.go
+++ b/internal/services/trust.go
@@ -204,7 +204,12 @@ func (s *trustService) GetTrustMetadataInfo(ctx context.Context, tufRepoUrl stri
 	}
 
 	result := models.MetadataInfoResponse{
-		Data:    map[string][]models.MetadataInfo{"root": rootEntries},
+		Data: map[string][]models.MetadataInfo{
+			"root":      rootEntries,
+			"targets":   {},
+			"snapshot":  {},
+			"timestamp": {},
+		},
 		RepoUrl: &repo.opts.RepositoryBaseURL,
 	}
 
@@ -775,7 +780,7 @@ func metadataInfoFromVersionAndExpires(version int64, expires time.Time) models.
 	switch {
 	case expires.Before(now):
 		status = "expired"
-	case expires.Sub(now) < 30*24*time.Hour:
+	case expires.Sub(now) <= 30*24*time.Hour:
 		status = "expiring"
 	default:
 		status = "valid"
@@ -810,7 +815,7 @@ func extractRootMetadataInfo(rootMetadataBytes []byte) (models.MetadataInfo, err
 	switch {
 	case expiresTime.Before(now):
 		status = "expired"
-	case expiresTime.Sub(now) < 30*24*time.Hour:
+	case expiresTime.Sub(now) <= 30*24*time.Hour:
 		status = "expiring"
 	default:
 		status = "valid"

--- a/internal/services/trust_test.go
+++ b/internal/services/trust_test.go
@@ -11,6 +11,7 @@ import (
 	"encoding/hex"
 	"encoding/pem"
 	"math/big"
+	"strconv"
 	"testing"
 	"time"
 
@@ -276,4 +277,62 @@ func TestGetValidForLookupCaching(t *testing.T) {
 			t.Errorf("expected cached map with 1 entry for equivalent URL, got %d", len(got))
 		}
 	})
+}
+
+func TestMetadataInfoFromVersionAndExpires(t *testing.T) {
+	now := time.Now().UTC()
+
+	tests := []struct {
+		name       string
+		version    int64
+		expires    time.Time
+		wantStatus string
+	}{
+		{
+			name:       "valid, far future",
+			version:    15,
+			expires:    now.Add(365 * 24 * time.Hour),
+			wantStatus: "valid",
+		},
+		{
+			name:       "expiring within 30 days",
+			version:    5,
+			expires:    now.Add(15 * 24 * time.Hour),
+			wantStatus: "expiring",
+		},
+		{
+			name:       "expired",
+			version:    1,
+			expires:    now.Add(-1 * time.Hour),
+			wantStatus: "expired",
+		},
+		{
+			name:       "boundary: exactly 30 days",
+			version:    10,
+			expires:    now.Add(30 * 24 * time.Hour),
+			wantStatus: "expiring",
+		},
+		{
+			name:       "boundary: 31 days",
+			version:    10,
+			expires:    now.Add(31 * 24 * time.Hour),
+			wantStatus: "valid",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := metadataInfoFromVersionAndExpires(tt.version, tt.expires)
+			if got.Status != tt.wantStatus {
+				t.Errorf("status = %q, want %q", got.Status, tt.wantStatus)
+			}
+			wantVersion := strconv.FormatInt(tt.version, 10)
+			if got.Version != wantVersion {
+				t.Errorf("version = %q, want %q", got.Version, wantVersion)
+			}
+			if _, err := time.Parse(time.RFC3339, got.Expires); err != nil {
+				t.Errorf("expires %q is not valid RFC3339: %v", got.Expires, err)
+			}
+		})
+	}
 }


### PR DESCRIPTION
Extend `/api/v1/trust/metadata-info` to return metadata for all 4 TUF roles (root, targets, snapshot, timestamp) instead of only root. Response is restructured as a dict keyed by role name.