### PR TITLE
feat: read all component health statuses from the Securesign CR conditions

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,6 @@ require (
 	github.com/theupdateframework/go-tuf v0.7.0
 	github.com/theupdateframework/go-tuf/v2 v2.4.2
 	google.golang.org/protobuf v1.36.11
-	k8s.io/api v0.33.1
 	k8s.io/apimachinery v0.33.1
 	k8s.io/client-go v0.33.1
 )
@@ -30,7 +29,6 @@ require (
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/digitorus/pkcs7 v0.0.0-20250730155240-ffadbf3f398c // indirect
 	github.com/digitorus/timestamp v0.0.0-20250524132541-c45532741eea // indirect
-	github.com/emicklei/go-restful/v3 v3.11.0 // indirect
 	github.com/fxamacker/cbor/v2 v2.9.0 // indirect
 	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect

--- a/internal/api/handlers_test.go
+++ b/internal/api/handlers_test.go
@@ -209,8 +209,12 @@ func TestGetApiV1SystemHealth(t *testing.T) {
 		hs := &mockHealthService{
 			getSystemHealthFn: func(context.Context) (models.SystemHealthResponse, int, error) {
 				return models.SystemHealthResponse{
+					SecuresignStatus: models.SystemHealthResponseSecuresignStatusHealthy,
 					RekorStatus:      models.SystemHealthResponseRekorStatusHealthy,
-					SigstoreServices: models.SystemHealthResponseSigstoreServicesHealthy,
+					FulcioStatus:     models.SystemHealthResponseFulcioStatusHealthy,
+					CtlogStatus:      models.SystemHealthResponseCtlogStatusHealthy,
+					TrillianStatus:   models.SystemHealthResponseTrillianStatusHealthy,
+					TsaStatus:        models.SystemHealthResponseTsaStatusHealthy,
 					TufStatus:        models.SystemHealthResponseTufStatusHealthy,
 				}, http.StatusOK, nil
 			},

--- a/internal/api/openapi/rhtas-console.yaml
+++ b/internal/api/openapi/rhtas-console.yaml
@@ -1169,15 +1169,35 @@ components:
     SystemHealthResponse:
       type: object
       properties:
-        sigstoreServices:
+        securesignStatus:
           type: string
           enum: ["healthy", "unhealthy", "unknown"]
-          description: Sigstore services health status
+          description: Overall Securesign operator health status
           example: healthy
         rekorStatus:
           type: string
           enum: ["healthy", "unhealthy", "unknown"]
           description: Rekor transparency log service health status
+          example: healthy
+        fulcioStatus:
+          type: string
+          enum: ["healthy", "unhealthy", "unknown"]
+          description: Fulcio certificate authority service health status
+          example: healthy
+        ctlogStatus:
+          type: string
+          enum: ["healthy", "unhealthy", "unknown"]
+          description: Certificate Transparency log service health status
+          example: healthy
+        trillianStatus:
+          type: string
+          enum: ["healthy", "unhealthy", "unknown"]
+          description: Trillian backend service health status
+          example: healthy
+        tsaStatus:
+          type: string
+          enum: ["healthy", "unhealthy", "unknown"]
+          description: Timestamp Authority service health status
           example: healthy
         tufStatus:
           type: string
@@ -1190,7 +1210,11 @@ components:
           description: Timestamp when the health status was last updated
           example: "2026-03-18T12:00:00Z"
       required:
-        - sigstoreServices
+        - securesignStatus
         - rekorStatus
+        - fulcioStatus
+        - ctlogStatus
+        - trillianStatus
+        - tsaStatus
         - tufStatus
         - updatedAt

--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -47,6 +47,20 @@ const (
 	Revoked  CertificateStatus = "revoked"
 )
 
+// Defines values for SystemHealthResponseCtlogStatus.
+const (
+	SystemHealthResponseCtlogStatusHealthy   SystemHealthResponseCtlogStatus = "healthy"
+	SystemHealthResponseCtlogStatusUnhealthy SystemHealthResponseCtlogStatus = "unhealthy"
+	SystemHealthResponseCtlogStatusUnknown   SystemHealthResponseCtlogStatus = "unknown"
+)
+
+// Defines values for SystemHealthResponseFulcioStatus.
+const (
+	SystemHealthResponseFulcioStatusHealthy   SystemHealthResponseFulcioStatus = "healthy"
+	SystemHealthResponseFulcioStatusUnhealthy SystemHealthResponseFulcioStatus = "unhealthy"
+	SystemHealthResponseFulcioStatusUnknown   SystemHealthResponseFulcioStatus = "unknown"
+)
+
 // Defines values for SystemHealthResponseRekorStatus.
 const (
 	SystemHealthResponseRekorStatusHealthy   SystemHealthResponseRekorStatus = "healthy"
@@ -54,11 +68,25 @@ const (
 	SystemHealthResponseRekorStatusUnknown   SystemHealthResponseRekorStatus = "unknown"
 )
 
-// Defines values for SystemHealthResponseSigstoreServices.
+// Defines values for SystemHealthResponseSecuresignStatus.
 const (
-	SystemHealthResponseSigstoreServicesHealthy   SystemHealthResponseSigstoreServices = "healthy"
-	SystemHealthResponseSigstoreServicesUnhealthy SystemHealthResponseSigstoreServices = "unhealthy"
-	SystemHealthResponseSigstoreServicesUnknown   SystemHealthResponseSigstoreServices = "unknown"
+	SystemHealthResponseSecuresignStatusHealthy   SystemHealthResponseSecuresignStatus = "healthy"
+	SystemHealthResponseSecuresignStatusUnhealthy SystemHealthResponseSecuresignStatus = "unhealthy"
+	SystemHealthResponseSecuresignStatusUnknown   SystemHealthResponseSecuresignStatus = "unknown"
+)
+
+// Defines values for SystemHealthResponseTrillianStatus.
+const (
+	SystemHealthResponseTrillianStatusHealthy   SystemHealthResponseTrillianStatus = "healthy"
+	SystemHealthResponseTrillianStatusUnhealthy SystemHealthResponseTrillianStatus = "unhealthy"
+	SystemHealthResponseTrillianStatusUnknown   SystemHealthResponseTrillianStatus = "unknown"
+)
+
+// Defines values for SystemHealthResponseTsaStatus.
+const (
+	SystemHealthResponseTsaStatusHealthy   SystemHealthResponseTsaStatus = "healthy"
+	SystemHealthResponseTsaStatusUnhealthy SystemHealthResponseTsaStatus = "unhealthy"
+	SystemHealthResponseTsaStatusUnknown   SystemHealthResponseTsaStatus = "unknown"
 )
 
 // Defines values for SystemHealthResponseTufStatus.
@@ -369,11 +397,23 @@ type SignatureView struct {
 
 // SystemHealthResponse defines model for SystemHealthResponse.
 type SystemHealthResponse struct {
+	// CtlogStatus Certificate Transparency log service health status
+	CtlogStatus SystemHealthResponseCtlogStatus `json:"ctlogStatus"`
+
+	// FulcioStatus Fulcio certificate authority service health status
+	FulcioStatus SystemHealthResponseFulcioStatus `json:"fulcioStatus"`
+
 	// RekorStatus Rekor transparency log service health status
 	RekorStatus SystemHealthResponseRekorStatus `json:"rekorStatus"`
 
-	// SigstoreServices Sigstore services health status
-	SigstoreServices SystemHealthResponseSigstoreServices `json:"sigstoreServices"`
+	// SecuresignStatus Overall Securesign operator health status
+	SecuresignStatus SystemHealthResponseSecuresignStatus `json:"securesignStatus"`
+
+	// TrillianStatus Trillian backend service health status
+	TrillianStatus SystemHealthResponseTrillianStatus `json:"trillianStatus"`
+
+	// TsaStatus Timestamp Authority service health status
+	TsaStatus SystemHealthResponseTsaStatus `json:"tsaStatus"`
 
 	// TufStatus TUF repository health status
 	TufStatus SystemHealthResponseTufStatus `json:"tufStatus"`
@@ -382,11 +422,23 @@ type SystemHealthResponse struct {
 	UpdatedAt time.Time `json:"updatedAt"`
 }
 
+// SystemHealthResponseCtlogStatus Certificate Transparency log service health status
+type SystemHealthResponseCtlogStatus string
+
+// SystemHealthResponseFulcioStatus Fulcio certificate authority service health status
+type SystemHealthResponseFulcioStatus string
+
 // SystemHealthResponseRekorStatus Rekor transparency log service health status
 type SystemHealthResponseRekorStatus string
 
-// SystemHealthResponseSigstoreServices Sigstore services health status
-type SystemHealthResponseSigstoreServices string
+// SystemHealthResponseSecuresignStatus Overall Securesign operator health status
+type SystemHealthResponseSecuresignStatus string
+
+// SystemHealthResponseTrillianStatus Trillian backend service health status
+type SystemHealthResponseTrillianStatus string
+
+// SystemHealthResponseTsaStatus Timestamp Authority service health status
+type SystemHealthResponseTsaStatus string
 
 // SystemHealthResponseTufStatus TUF repository health status
 type SystemHealthResponseTufStatus string

--- a/internal/services/health.go
+++ b/internal/services/health.go
@@ -3,7 +3,6 @@ package services
 import (
 	"context"
 	"fmt"
-	"log"
 	"net/http"
 	"os"
 	"time"
@@ -13,17 +12,21 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/dynamic"
-	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 )
+
+var securesignGVR = schema.GroupVersionResource{
+	Group:    "rhtas.redhat.com",
+	Version:  "v1alpha1",
+	Resource: "securesigns",
+}
 
 type HealthService interface {
 	GetSystemHealth(ctx context.Context) (models.SystemHealthResponse, int, error)
 }
 
 type healthService struct {
-	clientset     kubernetes.Interface
 	dynamicClient dynamic.Interface
 	namespace     string
 }
@@ -32,11 +35,6 @@ func NewHealthService() (HealthService, error) {
 	config, err := getKubeConfig()
 	if err != nil {
 		return nil, fmt.Errorf("failed to get kubernetes config: %w", err)
-	}
-
-	clientset, err := kubernetes.NewForConfig(config)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create kubernetes clientset: %w", err)
 	}
 
 	dynamicClient, err := dynamic.NewForConfig(config)
@@ -50,7 +48,6 @@ func NewHealthService() (HealthService, error) {
 	}
 
 	return &healthService{
-		clientset:     clientset,
 		dynamicClient: dynamicClient,
 		namespace:     namespace,
 	}, nil
@@ -71,164 +68,89 @@ func getKubeConfig() (*rest.Config, error) {
 }
 
 func (h *healthService) GetSystemHealth(ctx context.Context) (models.SystemHealthResponse, int, error) {
-	// Add timeout to prevent hanging on slow/hung Kubernetes API calls
 	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
 	defer cancel()
 
-	sigstoreServices := h.checkSigstoreServicesHealth(ctx)
-	rekorStatus := h.checkRekorHealth(ctx)
-	tufStatus := h.checkTUFHealth(ctx)
+	conditions, err := h.getSecuresignConditions(ctx)
+	if err != nil {
+		return models.SystemHealthResponse{}, http.StatusInternalServerError, fmt.Errorf("failed to read Securesign CR: %w", err)
+	}
 
 	return models.SystemHealthResponse{
-		SigstoreServices: sigstoreServices,
-		RekorStatus:      rekorStatus,
-		TufStatus:        tufStatus,
-		UpdatedAt:        time.Now().UTC(),
+		SecuresignStatus: mapCondition(conditions["Ready"],
+			models.SystemHealthResponseSecuresignStatusHealthy,
+			models.SystemHealthResponseSecuresignStatusUnhealthy,
+			models.SystemHealthResponseSecuresignStatusUnknown),
+		RekorStatus: mapCondition(conditions["RekorAvailable"],
+			models.SystemHealthResponseRekorStatusHealthy,
+			models.SystemHealthResponseRekorStatusUnhealthy,
+			models.SystemHealthResponseRekorStatusUnknown),
+		FulcioStatus: mapCondition(conditions["FulcioAvailable"],
+			models.SystemHealthResponseFulcioStatusHealthy,
+			models.SystemHealthResponseFulcioStatusUnhealthy,
+			models.SystemHealthResponseFulcioStatusUnknown),
+		CtlogStatus: mapCondition(conditions["CTlogAvailable"],
+			models.SystemHealthResponseCtlogStatusHealthy,
+			models.SystemHealthResponseCtlogStatusUnhealthy,
+			models.SystemHealthResponseCtlogStatusUnknown),
+		TrillianStatus: mapCondition(conditions["TrillianAvailable"],
+			models.SystemHealthResponseTrillianStatusHealthy,
+			models.SystemHealthResponseTrillianStatusUnhealthy,
+			models.SystemHealthResponseTrillianStatusUnknown),
+		TsaStatus: mapCondition(conditions["TsaAvailable"],
+			models.SystemHealthResponseTsaStatusHealthy,
+			models.SystemHealthResponseTsaStatusUnhealthy,
+			models.SystemHealthResponseTsaStatusUnknown),
+		TufStatus: mapCondition(conditions["TufAvailable"],
+			models.SystemHealthResponseTufStatusHealthy,
+			models.SystemHealthResponseTufStatusUnhealthy,
+			models.SystemHealthResponseTufStatusUnknown),
+		UpdatedAt: time.Now().UTC(),
 	}, http.StatusOK, nil
 }
 
-func (h *healthService) checkSigstoreServicesHealth(ctx context.Context) models.SystemHealthResponseSigstoreServices {
-	deploymentName := os.Getenv("TAS_DEPLOYMENT_NAME")
-	if deploymentName == "" {
-		deploymentName = "securesign-sample"
-	}
-
-	crHealthy, err := h.checkCustomResourceHealth(ctx, "securesigns", deploymentName)
-	if err != nil || !crHealthy {
-		return models.SystemHealthResponseSigstoreServicesUnhealthy
-	}
-
-	return models.SystemHealthResponseSigstoreServicesHealthy
-}
-
-func (h *healthService) checkRekorHealth(ctx context.Context) models.SystemHealthResponseRekorStatus {
-	crName := os.Getenv("REKOR_CR_NAME")
+func (h *healthService) getSecuresignConditions(ctx context.Context) (map[string]string, error) {
+	crName := os.Getenv("TAS_DEPLOYMENT_NAME")
 	if crName == "" {
-		log.Printf("REKOR_CR_NAME environment variable not set")
-		return models.SystemHealthResponseRekorStatusUnknown
+		crName = "securesign-sample"
 	}
 
-	deploymentName := os.Getenv("REKOR_DEPLOYMENT_NAME")
-	if deploymentName == "" {
-		deploymentName = "rekor-server"
-	}
-
-	crHealthy, err := h.checkCustomResourceHealth(ctx, "rekors", crName)
-	if err != nil || !crHealthy {
-		return models.SystemHealthResponseRekorStatusUnhealthy
-	}
-
-	podHealthy := h.checkDeploymentHealth(ctx, deploymentName)
-	if !podHealthy {
-		return models.SystemHealthResponseRekorStatusUnhealthy
-	}
-
-	endpointHealthy := h.checkHTTPHealth(ctx, "http://"+deploymentName+"."+h.namespace+".svc:80/api/v1/log")
-	if !endpointHealthy {
-		return models.SystemHealthResponseRekorStatusUnhealthy
-	}
-
-	return models.SystemHealthResponseRekorStatusHealthy
-}
-
-func (h *healthService) checkTUFHealth(ctx context.Context) models.SystemHealthResponseTufStatus {
-	crName := os.Getenv("TUF_CR_NAME")
-	if crName == "" {
-		log.Printf("TUF_CR_NAME environment variable not set")
-		return models.SystemHealthResponseTufStatusUnknown
-	}
-
-	deploymentName := os.Getenv("TUF_DEPLOYMENT_NAME")
-	if deploymentName == "" {
-		deploymentName = "tuf"
-	}
-
-	crHealthy, err := h.checkCustomResourceHealth(ctx, "tufs", crName)
-	if err != nil || !crHealthy {
-		return models.SystemHealthResponseTufStatusUnhealthy
-	}
-
-	podHealthy := h.checkDeploymentHealth(ctx, deploymentName)
-	if !podHealthy {
-		return models.SystemHealthResponseTufStatusUnhealthy
-	}
-
-	return models.SystemHealthResponseTufStatusHealthy
-}
-
-func (h *healthService) checkCustomResourceHealth(ctx context.Context, resourceType, name string) (bool, error) {
-	gvr := schema.GroupVersionResource{
-		Group:    "rhtas.redhat.com",
-		Version:  "v1alpha1",
-		Resource: resourceType,
-	}
-
-	resource, err := h.dynamicClient.Resource(gvr).Namespace(h.namespace).Get(ctx, name, metav1.GetOptions{})
+	resource, err := h.dynamicClient.Resource(securesignGVR).Namespace(h.namespace).Get(ctx, crName, metav1.GetOptions{})
 	if err != nil {
-		return false, err
+		return nil, fmt.Errorf("failed to get securesign CR %q: %w", crName, err)
 	}
 
-	conditions, found, err := unstructured.NestedSlice(resource.Object, "status", "conditions")
+	rawConditions, found, err := unstructured.NestedSlice(resource.Object, "status", "conditions")
 	if err != nil {
-		return false, fmt.Errorf("failed to get conditions: %w", err)
+		return nil, fmt.Errorf("failed to read conditions: %w", err)
 	}
 	if !found {
-		return false, fmt.Errorf("conditions not found in status")
+		return nil, fmt.Errorf("no conditions found on securesign CR %q", crName)
 	}
 
-	for _, condition := range conditions {
-		condMap, ok := condition.(map[string]interface{})
+	conditions := make(map[string]string, len(rawConditions))
+	for _, c := range rawConditions {
+		condMap, ok := c.(map[string]interface{})
 		if !ok {
 			continue
 		}
-
 		condType, _ := condMap["type"].(string)
 		condStatus, _ := condMap["status"].(string)
-
-		if condType == "Ready" && condStatus == "True" {
-			return true, nil
+		if condType != "" {
+			conditions[condType] = condStatus
 		}
 	}
 
-	return false, nil
+	return conditions, nil
 }
 
-func (h *healthService) checkDeploymentHealth(ctx context.Context, deploymentName string) bool {
-	deployment, err := h.clientset.AppsV1().Deployments(h.namespace).Get(ctx, deploymentName, metav1.GetOptions{})
-	if err != nil {
-		return false
+func mapCondition[T ~string](status string, healthy, unhealthy, unknown T) T {
+	switch status {
+	case "True":
+		return healthy
+	case "False":
+		return unhealthy
+	default:
+		return unknown
 	}
-
-	if deployment.Status.Replicas == 0 {
-		return false
-	}
-
-	if deployment.Status.ReadyReplicas < deployment.Status.Replicas {
-		return false
-	}
-
-	return true
-}
-
-func (h *healthService) checkHTTPHealth(ctx context.Context, url string) bool {
-	client := &http.Client{
-		Timeout: 5 * time.Second,
-	}
-
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
-	if err != nil {
-		return false
-	}
-
-	resp, err := client.Do(req)
-	if err != nil {
-		return false
-	}
-	defer func() {
-		if cerr := resp.Body.Close(); cerr != nil {
-			log.Printf("Failed to close response body: %v", cerr)
-		}
-	}()
-
-	return resp.StatusCode == http.StatusOK
 }

--- a/internal/services/health_test.go
+++ b/internal/services/health_test.go
@@ -3,53 +3,35 @@ package services
 import (
 	"context"
 	"net/http"
-	"net/http/httptest"
 	"testing"
 
 	"github.com/securesign/rhtas-console/internal/models"
-	appsv1 "k8s.io/api/apps/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/dynamic/fake"
-	kubefake "k8s.io/client-go/kubernetes/fake"
 )
 
 const testNamespace = "test-ns"
 
-func newTestHealthService(objs []runtime.Object, dynamicObjs ...runtime.Object) *healthService {
-	clientset := kubefake.NewSimpleClientset(objs...)
+func newTestHealthService(dynamicObjs ...runtime.Object) *healthService {
 	scheme := runtime.NewScheme()
 	gvrToListKind := map[schema.GroupVersionResource]string{
-		{Group: "rhtas.redhat.com", Version: "v1alpha1", Resource: "securesigns"}: "SecuresignList",
-		{Group: "rhtas.redhat.com", Version: "v1alpha1", Resource: "rekors"}:      "RekorList",
-		{Group: "rhtas.redhat.com", Version: "v1alpha1", Resource: "tufs"}:        "TufList",
+		securesignGVR: "SecuresignList",
 	}
 	dynamicClient := fake.NewSimpleDynamicClientWithCustomListKinds(scheme, gvrToListKind, dynamicObjs...)
 	return &healthService{
-		clientset:     clientset,
 		dynamicClient: dynamicClient,
 		namespace:     testNamespace,
 	}
 }
 
-var resourceToKind = map[string]string{
-	"securesigns": "Securesign",
-	"rekors":      "Rekor",
-	"tufs":        "Tuf",
-}
-
-func makeUnstructuredCR(resource, name, namespace string, conditions []interface{}) *unstructured.Unstructured {
-	kind := resourceToKind[resource]
-	if kind == "" {
-		kind = resource
-	}
+func makeSecuresignCR(name, namespace string, conditions []interface{}) *unstructured.Unstructured {
 	obj := &unstructured.Unstructured{}
 	obj.SetGroupVersionKind(schema.GroupVersionKind{
 		Group:   "rhtas.redhat.com",
 		Version: "v1alpha1",
-		Kind:    kind,
+		Kind:    "Securesign",
 	})
 	obj.SetName(name)
 	obj.SetNamespace(namespace)
@@ -61,317 +43,92 @@ func makeUnstructuredCR(resource, name, namespace string, conditions []interface
 	return obj
 }
 
-func TestCheckDeploymentHealth(t *testing.T) {
+func cond(condType, status string) map[string]interface{} {
+	return map[string]interface{}{"type": condType, "status": status}
+}
+
+func allHealthyConditions() []interface{} {
+	return []interface{}{
+		cond("Ready", "True"),
+		cond("RekorAvailable", "True"),
+		cond("FulcioAvailable", "True"),
+		cond("CTlogAvailable", "True"),
+		cond("TrillianAvailable", "True"),
+		cond("TsaAvailable", "True"),
+		cond("TufAvailable", "True"),
+	}
+}
+
+func TestGetSecuresignConditions(t *testing.T) {
+	t.Run("all conditions present", func(t *testing.T) {
+		t.Setenv("TAS_DEPLOYMENT_NAME", "securesign-sample")
+		cr := makeSecuresignCR("securesign-sample", testNamespace, allHealthyConditions())
+		h := newTestHealthService(cr)
+
+		conditions, err := h.getSecuresignConditions(context.Background())
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(conditions) != 7 {
+			t.Errorf("expected 7 conditions, got %d", len(conditions))
+		}
+		if conditions["Ready"] != "True" {
+			t.Errorf("Ready = %q, want %q", conditions["Ready"], "True")
+		}
+	})
+
+	t.Run("CR not found", func(t *testing.T) {
+		t.Setenv("TAS_DEPLOYMENT_NAME", "missing")
+		h := newTestHealthService()
+
+		_, err := h.getSecuresignConditions(context.Background())
+		if err == nil {
+			t.Error("expected error for missing CR, got nil")
+		}
+	})
+
+	t.Run("CR with no conditions", func(t *testing.T) {
+		t.Setenv("TAS_DEPLOYMENT_NAME", "securesign-sample")
+		cr := makeSecuresignCR("securesign-sample", testNamespace, nil)
+		h := newTestHealthService(cr)
+
+		_, err := h.getSecuresignConditions(context.Background())
+		if err == nil {
+			t.Error("expected error for missing conditions, got nil")
+		}
+	})
+}
+
+func TestMapCondition(t *testing.T) {
+	type result = models.SystemHealthResponseRekorStatus
+	healthy := models.SystemHealthResponseRekorStatusHealthy
+	unhealthy := models.SystemHealthResponseRekorStatusUnhealthy
+	unknown := models.SystemHealthResponseRekorStatusUnknown
+
 	tests := []struct {
-		name       string
-		deployment *appsv1.Deployment
-		want       bool
+		status string
+		want   result
 	}{
-		{
-			name: "healthy: ready equals replicas",
-			deployment: &appsv1.Deployment{
-				ObjectMeta: metav1.ObjectMeta{Name: "test-deploy", Namespace: testNamespace},
-				Status: appsv1.DeploymentStatus{
-					Replicas:      3,
-					ReadyReplicas: 3,
-				},
-			},
-			want: true,
-		},
-		{
-			name: "unhealthy: ready less than replicas",
-			deployment: &appsv1.Deployment{
-				ObjectMeta: metav1.ObjectMeta{Name: "test-deploy", Namespace: testNamespace},
-				Status: appsv1.DeploymentStatus{
-					Replicas:      3,
-					ReadyReplicas: 1,
-				},
-			},
-			want: false,
-		},
-		{
-			name: "unhealthy: zero replicas",
-			deployment: &appsv1.Deployment{
-				ObjectMeta: metav1.ObjectMeta{Name: "test-deploy", Namespace: testNamespace},
-				Status: appsv1.DeploymentStatus{
-					Replicas:      0,
-					ReadyReplicas: 0,
-				},
-			},
-			want: false,
-		},
-		{
-			name:       "unhealthy: deployment does not exist",
-			deployment: nil,
-			want:       false,
-		},
+		{"True", healthy},
+		{"False", unhealthy},
+		{"", unknown},
+		{"Unknown", unknown},
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			var objs []runtime.Object
-			if tt.deployment != nil {
-				objs = append(objs, tt.deployment)
-			}
-			h := newTestHealthService(objs)
-			got := h.checkDeploymentHealth(context.Background(), "test-deploy")
-			if got != tt.want {
-				t.Errorf("checkDeploymentHealth() = %v, want %v", got, tt.want)
-			}
-		})
+		got := mapCondition(tt.status, healthy, unhealthy, unknown)
+		if got != tt.want {
+			t.Errorf("mapCondition(%q) = %q, want %q", tt.status, got, tt.want)
+		}
 	}
-}
-
-func TestCheckCustomResourceHealth(t *testing.T) {
-	tests := []struct {
-		name         string
-		cr           *unstructured.Unstructured
-		resourceType string
-		crName       string
-		wantHealthy  bool
-		wantErr      bool
-	}{
-		{
-			name: "ready condition true",
-			cr: makeUnstructuredCR("securesigns", "my-cr", testNamespace, []interface{}{
-				map[string]interface{}{
-					"type":   "Ready",
-					"status": "True",
-				},
-			}),
-			resourceType: "securesigns",
-			crName:       "my-cr",
-			wantHealthy:  true,
-			wantErr:      false,
-		},
-		{
-			name: "ready condition false",
-			cr: makeUnstructuredCR("securesigns", "my-cr", testNamespace, []interface{}{
-				map[string]interface{}{
-					"type":   "Ready",
-					"status": "False",
-				},
-			}),
-			resourceType: "securesigns",
-			crName:       "my-cr",
-			wantHealthy:  false,
-			wantErr:      false,
-		},
-		{
-			name:         "CR does not exist",
-			cr:           nil,
-			resourceType: "securesigns",
-			crName:       "missing-cr",
-			wantHealthy:  false,
-			wantErr:      true,
-		},
-		{
-			name:         "CR with no conditions",
-			cr:           makeUnstructuredCR("securesigns", "my-cr", testNamespace, nil),
-			resourceType: "securesigns",
-			crName:       "my-cr",
-			wantHealthy:  false,
-			wantErr:      true,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			var dynamicObjs []runtime.Object
-			if tt.cr != nil {
-				dynamicObjs = append(dynamicObjs, tt.cr)
-			}
-			h := newTestHealthService(nil, dynamicObjs...)
-			got, err := h.checkCustomResourceHealth(context.Background(), tt.resourceType, tt.crName)
-			if tt.wantErr && err == nil {
-				t.Error("expected error, got nil")
-			}
-			if !tt.wantErr && err != nil {
-				t.Errorf("unexpected error: %v", err)
-			}
-			if got != tt.wantHealthy {
-				t.Errorf("checkCustomResourceHealth() = %v, want %v", got, tt.wantHealthy)
-			}
-		})
-	}
-}
-
-func TestCheckHTTPHealth(t *testing.T) {
-	t.Run("server returns 200", func(t *testing.T) {
-		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			w.WriteHeader(http.StatusOK)
-		}))
-		defer srv.Close()
-
-		h := newTestHealthService(nil)
-		if !h.checkHTTPHealth(context.Background(), srv.URL) {
-			t.Error("expected true for 200 response")
-		}
-	})
-
-	t.Run("server returns 500", func(t *testing.T) {
-		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			w.WriteHeader(http.StatusInternalServerError)
-		}))
-		defer srv.Close()
-
-		h := newTestHealthService(nil)
-		if h.checkHTTPHealth(context.Background(), srv.URL) {
-			t.Error("expected false for 500 response")
-		}
-	})
-
-	t.Run("server unreachable", func(t *testing.T) {
-		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
-		srv.Close()
-
-		h := newTestHealthService(nil)
-		if h.checkHTTPHealth(context.Background(), srv.URL) {
-			t.Error("expected false for unreachable server")
-		}
-	})
-}
-
-func TestCheckSigstoreServicesHealth(t *testing.T) {
-	t.Run("healthy CR", func(t *testing.T) {
-		t.Setenv("TAS_DEPLOYMENT_NAME", "securesign-sample")
-		cr := makeUnstructuredCR("securesigns", "securesign-sample", testNamespace, []interface{}{
-			map[string]interface{}{"type": "Ready", "status": "True"},
-		})
-		h := newTestHealthService(nil, cr)
-		got := h.checkSigstoreServicesHealth(context.Background())
-		if got != models.SystemHealthResponseSigstoreServicesHealthy {
-			t.Errorf("got %q, want %q", got, models.SystemHealthResponseSigstoreServicesHealthy)
-		}
-	})
-
-	t.Run("unhealthy CR", func(t *testing.T) {
-		t.Setenv("TAS_DEPLOYMENT_NAME", "securesign-sample")
-		cr := makeUnstructuredCR("securesigns", "securesign-sample", testNamespace, []interface{}{
-			map[string]interface{}{"type": "Ready", "status": "False"},
-		})
-		h := newTestHealthService(nil, cr)
-		got := h.checkSigstoreServicesHealth(context.Background())
-		if got != models.SystemHealthResponseSigstoreServicesUnhealthy {
-			t.Errorf("got %q, want %q", got, models.SystemHealthResponseSigstoreServicesUnhealthy)
-		}
-	})
-}
-
-func TestCheckTUFHealth(t *testing.T) {
-	t.Run("TUF_CR_NAME not set", func(t *testing.T) {
-		t.Setenv("TUF_CR_NAME", "")
-		h := newTestHealthService(nil)
-		got := h.checkTUFHealth(context.Background())
-		if got != models.SystemHealthResponseTufStatusUnknown {
-			t.Errorf("got %q, want %q", got, models.SystemHealthResponseTufStatusUnknown)
-		}
-	})
-
-	t.Run("healthy CR and deployment", func(t *testing.T) {
-		t.Setenv("TUF_CR_NAME", "my-tuf")
-		t.Setenv("TUF_DEPLOYMENT_NAME", "tuf")
-
-		cr := makeUnstructuredCR("tufs", "my-tuf", testNamespace, []interface{}{
-			map[string]interface{}{"type": "Ready", "status": "True"},
-		})
-		deploy := &appsv1.Deployment{
-			ObjectMeta: metav1.ObjectMeta{Name: "tuf", Namespace: testNamespace},
-			Status:     appsv1.DeploymentStatus{Replicas: 1, ReadyReplicas: 1},
-		}
-		h := newTestHealthService([]runtime.Object{deploy}, cr)
-		got := h.checkTUFHealth(context.Background())
-		if got != models.SystemHealthResponseTufStatusHealthy {
-			t.Errorf("got %q, want %q", got, models.SystemHealthResponseTufStatusHealthy)
-		}
-	})
-
-	t.Run("unhealthy CR", func(t *testing.T) {
-		t.Setenv("TUF_CR_NAME", "my-tuf")
-		t.Setenv("TUF_DEPLOYMENT_NAME", "tuf")
-
-		cr := makeUnstructuredCR("tufs", "my-tuf", testNamespace, []interface{}{
-			map[string]interface{}{"type": "Ready", "status": "False"},
-		})
-		h := newTestHealthService(nil, cr)
-		got := h.checkTUFHealth(context.Background())
-		if got != models.SystemHealthResponseTufStatusUnhealthy {
-			t.Errorf("got %q, want %q", got, models.SystemHealthResponseTufStatusUnhealthy)
-		}
-	})
-
-	t.Run("unhealthy deployment", func(t *testing.T) {
-		t.Setenv("TUF_CR_NAME", "my-tuf")
-		t.Setenv("TUF_DEPLOYMENT_NAME", "tuf")
-
-		cr := makeUnstructuredCR("tufs", "my-tuf", testNamespace, []interface{}{
-			map[string]interface{}{"type": "Ready", "status": "True"},
-		})
-		deploy := &appsv1.Deployment{
-			ObjectMeta: metav1.ObjectMeta{Name: "tuf", Namespace: testNamespace},
-			Status:     appsv1.DeploymentStatus{Replicas: 2, ReadyReplicas: 0},
-		}
-		h := newTestHealthService([]runtime.Object{deploy}, cr)
-		got := h.checkTUFHealth(context.Background())
-		if got != models.SystemHealthResponseTufStatusUnhealthy {
-			t.Errorf("got %q, want %q", got, models.SystemHealthResponseTufStatusUnhealthy)
-		}
-	})
-}
-
-func TestCheckRekorHealth(t *testing.T) {
-	t.Run("REKOR_CR_NAME not set", func(t *testing.T) {
-		t.Setenv("REKOR_CR_NAME", "")
-		h := newTestHealthService(nil)
-		got := h.checkRekorHealth(context.Background())
-		if got != models.SystemHealthResponseRekorStatusUnknown {
-			t.Errorf("got %q, want %q", got, models.SystemHealthResponseRekorStatusUnknown)
-		}
-	})
-
-	t.Run("unhealthy CR", func(t *testing.T) {
-		t.Setenv("REKOR_CR_NAME", "my-rekor")
-		t.Setenv("REKOR_DEPLOYMENT_NAME", "rekor-server")
-
-		cr := makeUnstructuredCR("rekors", "my-rekor", testNamespace, []interface{}{
-			map[string]interface{}{"type": "Ready", "status": "False"},
-		})
-		h := newTestHealthService(nil, cr)
-		got := h.checkRekorHealth(context.Background())
-		if got != models.SystemHealthResponseRekorStatusUnhealthy {
-			t.Errorf("got %q, want %q", got, models.SystemHealthResponseRekorStatusUnhealthy)
-		}
-	})
-
-	t.Run("healthy CR but unhealthy deployment", func(t *testing.T) {
-		t.Setenv("REKOR_CR_NAME", "my-rekor")
-		t.Setenv("REKOR_DEPLOYMENT_NAME", "rekor-server")
-
-		cr := makeUnstructuredCR("rekors", "my-rekor", testNamespace, []interface{}{
-			map[string]interface{}{"type": "Ready", "status": "True"},
-		})
-		deploy := &appsv1.Deployment{
-			ObjectMeta: metav1.ObjectMeta{Name: "rekor-server", Namespace: testNamespace},
-			Status:     appsv1.DeploymentStatus{Replicas: 2, ReadyReplicas: 0},
-		}
-		h := newTestHealthService([]runtime.Object{deploy}, cr)
-		got := h.checkRekorHealth(context.Background())
-		if got != models.SystemHealthResponseRekorStatusUnhealthy {
-			t.Errorf("got %q, want %q", got, models.SystemHealthResponseRekorStatusUnhealthy)
-		}
-	})
 }
 
 func TestGetSystemHealth(t *testing.T) {
-	t.Run("missing env vars returns unknown for rekor and tuf", func(t *testing.T) {
-		t.Setenv("REKOR_CR_NAME", "")
-		t.Setenv("TUF_CR_NAME", "")
+	t.Run("all components healthy", func(t *testing.T) {
 		t.Setenv("TAS_DEPLOYMENT_NAME", "securesign-sample")
+		cr := makeSecuresignCR("securesign-sample", testNamespace, allHealthyConditions())
+		h := newTestHealthService(cr)
 
-		cr := makeUnstructuredCR("securesigns", "securesign-sample", testNamespace, []interface{}{
-			map[string]interface{}{"type": "Ready", "status": "True"},
-		})
-		h := newTestHealthService(nil, cr)
 		resp, statusCode, err := h.GetSystemHealth(context.Background())
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
@@ -379,14 +136,125 @@ func TestGetSystemHealth(t *testing.T) {
 		if statusCode != http.StatusOK {
 			t.Errorf("status = %d, want %d", statusCode, http.StatusOK)
 		}
-		if resp.RekorStatus != models.SystemHealthResponseRekorStatusUnknown {
-			t.Errorf("RekorStatus = %q, want %q", resp.RekorStatus, models.SystemHealthResponseRekorStatusUnknown)
+		if resp.SecuresignStatus != models.SystemHealthResponseSecuresignStatusHealthy {
+			t.Errorf("SecuresignStatus = %q, want %q", resp.SecuresignStatus, models.SystemHealthResponseSecuresignStatusHealthy)
 		}
-		if resp.TufStatus != models.SystemHealthResponseTufStatusUnknown {
-			t.Errorf("TufStatus = %q, want %q", resp.TufStatus, models.SystemHealthResponseTufStatusUnknown)
+		if resp.RekorStatus != models.SystemHealthResponseRekorStatusHealthy {
+			t.Errorf("RekorStatus = %q, want %q", resp.RekorStatus, models.SystemHealthResponseRekorStatusHealthy)
 		}
-		if resp.SigstoreServices != models.SystemHealthResponseSigstoreServicesHealthy {
-			t.Errorf("SigstoreServices = %q, want %q", resp.SigstoreServices, models.SystemHealthResponseSigstoreServicesHealthy)
+		if resp.FulcioStatus != models.SystemHealthResponseFulcioStatusHealthy {
+			t.Errorf("FulcioStatus = %q, want %q", resp.FulcioStatus, models.SystemHealthResponseFulcioStatusHealthy)
+		}
+		if resp.CtlogStatus != models.SystemHealthResponseCtlogStatusHealthy {
+			t.Errorf("CtlogStatus = %q, want %q", resp.CtlogStatus, models.SystemHealthResponseCtlogStatusHealthy)
+		}
+		if resp.TrillianStatus != models.SystemHealthResponseTrillianStatusHealthy {
+			t.Errorf("TrillianStatus = %q, want %q", resp.TrillianStatus, models.SystemHealthResponseTrillianStatusHealthy)
+		}
+		if resp.TsaStatus != models.SystemHealthResponseTsaStatusHealthy {
+			t.Errorf("TsaStatus = %q, want %q", resp.TsaStatus, models.SystemHealthResponseTsaStatusHealthy)
+		}
+		if resp.TufStatus != models.SystemHealthResponseTufStatusHealthy {
+			t.Errorf("TufStatus = %q, want %q", resp.TufStatus, models.SystemHealthResponseTufStatusHealthy)
+		}
+	})
+
+	t.Run("mixed component statuses", func(t *testing.T) {
+		t.Setenv("TAS_DEPLOYMENT_NAME", "securesign-sample")
+		cr := makeSecuresignCR("securesign-sample", testNamespace, []interface{}{
+			cond("Ready", "False"),
+			cond("RekorAvailable", "True"),
+			cond("FulcioAvailable", "False"),
+			cond("CTlogAvailable", "True"),
+			cond("TrillianAvailable", "False"),
+			cond("TsaAvailable", "True"),
+			cond("TufAvailable", "False"),
+		})
+		h := newTestHealthService(cr)
+
+		resp, statusCode, err := h.GetSystemHealth(context.Background())
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if statusCode != http.StatusOK {
+			t.Errorf("status = %d, want %d", statusCode, http.StatusOK)
+		}
+		if resp.SecuresignStatus != models.SystemHealthResponseSecuresignStatusUnhealthy {
+			t.Errorf("SecuresignStatus = %q, want %q", resp.SecuresignStatus, models.SystemHealthResponseSecuresignStatusUnhealthy)
+		}
+		if resp.RekorStatus != models.SystemHealthResponseRekorStatusHealthy {
+			t.Errorf("RekorStatus = %q, want %q", resp.RekorStatus, models.SystemHealthResponseRekorStatusHealthy)
+		}
+		if resp.FulcioStatus != models.SystemHealthResponseFulcioStatusUnhealthy {
+			t.Errorf("FulcioStatus = %q, want %q", resp.FulcioStatus, models.SystemHealthResponseFulcioStatusUnhealthy)
+		}
+		if resp.CtlogStatus != models.SystemHealthResponseCtlogStatusHealthy {
+			t.Errorf("CtlogStatus = %q, want %q", resp.CtlogStatus, models.SystemHealthResponseCtlogStatusHealthy)
+		}
+		if resp.TrillianStatus != models.SystemHealthResponseTrillianStatusUnhealthy {
+			t.Errorf("TrillianStatus = %q, want %q", resp.TrillianStatus, models.SystemHealthResponseTrillianStatusUnhealthy)
+		}
+		if resp.TsaStatus != models.SystemHealthResponseTsaStatusHealthy {
+			t.Errorf("TsaStatus = %q, want %q", resp.TsaStatus, models.SystemHealthResponseTsaStatusHealthy)
+		}
+		if resp.TufStatus != models.SystemHealthResponseTufStatusUnhealthy {
+			t.Errorf("TufStatus = %q, want %q", resp.TufStatus, models.SystemHealthResponseTufStatusUnhealthy)
+		}
+	})
+
+	t.Run("CR not found returns error", func(t *testing.T) {
+		t.Setenv("TAS_DEPLOYMENT_NAME", "missing")
+		h := newTestHealthService()
+
+		_, statusCode, err := h.GetSystemHealth(context.Background())
+		if err == nil {
+			t.Fatal("expected error for missing CR, got nil")
+		}
+		if statusCode != http.StatusInternalServerError {
+			t.Errorf("status = %d, want %d", statusCode, http.StatusInternalServerError)
+		}
+	})
+
+	t.Run("missing condition returns unknown for that component", func(t *testing.T) {
+		t.Setenv("TAS_DEPLOYMENT_NAME", "securesign-sample")
+		cr := makeSecuresignCR("securesign-sample", testNamespace, []interface{}{
+			cond("Ready", "True"),
+			cond("RekorAvailable", "True"),
+		})
+		h := newTestHealthService(cr)
+
+		resp, _, err := h.GetSystemHealth(context.Background())
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp.SecuresignStatus != models.SystemHealthResponseSecuresignStatusHealthy {
+			t.Errorf("SecuresignStatus = %q, want %q", resp.SecuresignStatus, models.SystemHealthResponseSecuresignStatusHealthy)
+		}
+		if resp.RekorStatus != models.SystemHealthResponseRekorStatusHealthy {
+			t.Errorf("RekorStatus = %q, want %q", resp.RekorStatus, models.SystemHealthResponseRekorStatusHealthy)
+		}
+		if resp.FulcioStatus != models.SystemHealthResponseFulcioStatusUnknown {
+			t.Errorf("FulcioStatus = %q, want %q", resp.FulcioStatus, models.SystemHealthResponseFulcioStatusUnknown)
+		}
+		if resp.TsaStatus != models.SystemHealthResponseTsaStatusUnknown {
+			t.Errorf("TsaStatus = %q, want %q", resp.TsaStatus, models.SystemHealthResponseTsaStatusUnknown)
+		}
+	})
+
+	t.Run("defaults to securesign-sample when TAS_DEPLOYMENT_NAME not set", func(t *testing.T) {
+		t.Setenv("TAS_DEPLOYMENT_NAME", "")
+		cr := makeSecuresignCR("securesign-sample", testNamespace, allHealthyConditions())
+		h := newTestHealthService(cr)
+
+		resp, statusCode, err := h.GetSystemHealth(context.Background())
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if statusCode != http.StatusOK {
+			t.Errorf("status = %d, want %d", statusCode, http.StatusOK)
+		}
+		if resp.SecuresignStatus != models.SystemHealthResponseSecuresignStatusHealthy {
+			t.Errorf("SecuresignStatus = %q, want %q", resp.SecuresignStatus, models.SystemHealthResponseSecuresignStatusHealthy)
 		}
 	})
 }


### PR DESCRIPTION
Assisted with Claude Code.

- Add health status for all RHTAS components (Fulcio, CTlog, Trillian, TSA) alongside existing Rekor and TUF
- Refactor health service to read component statuses directly from the Securesign CR conditions (`RekorAvailable`, `FulcioAvailable`, `CTlogAvailable`, `TrillianAvailable`, `TsaAvailable`, `TufAvailable`) instead of querying each component's CR, deployment, and HTTP endpoints individually
- Rename `sigstoreServices` to `securesignStatus` in the API response for clarity
- Drop `k8s.io/client-go/kubernetes` clientset dependency since deployment and HTTP health checks are no longer needed, the operator is the source of truth.

Endpoint output example:
```
# curl http://localhost:8080/api/v1/system/health
{
  "ctlogStatus": "healthy",
  "fulcioStatus": "healthy",
  "rekorStatus": "healthy",
  "securesignStatus": "healthy",
  "trillianStatus": "healthy",
  "tsaStatus": "healthy",
  "tufStatus": "healthy",
  "updatedAt": "2026-08-04T15:25:01.633401858Z"
}
```

cc @stanislavsemeniuk @kahboom 